### PR TITLE
allow type coercion for fields

### DIFF
--- a/invoice2data/extract/invoice_template.py
+++ b/invoice2data/extract/invoice_template.py
@@ -169,6 +169,10 @@ class InvoiceTemplate(OrderedDict):
             if plugin_keyword in self.keys():
                 plugin_func.extract(self, optimized_str, output)
 
+        # apply type coercion for fields if specified
+        for typed_field in (field for field in output if field in self.get('types', {})):
+            output[typed_field] = self.coerce_type(output[typed_field], self['types'][typed_field])
+
         # If required fields were found, return output, else log error.
         if set(['date', 'amount', 'invoice_number', 'issuer']).issubset(output.keys()):
             output['desc'] = 'Invoice %s from %s' % (


### PR DESCRIPTION
Not sure if this is considered useful since there is a possibility to force basic type coercion by prefixing the fields with 'date' or 'amount'. But since explicit is better than implicit, maybe it is.