### PR TITLE
fix unclosed file warning when loading templates

### DIFF
--- a/invoice2data/extract/loader.py
+++ b/invoice2data/extract/loader.py
@@ -82,7 +82,9 @@ def read_templates(folder=None):
     for path, subdirs, files in os.walk(folder):
         for name in sorted(files):
             if name.endswith('.yml'):
-                with codecs.open(os.path.join(path, name), encoding=chardet.detect(open(os.path.join(path, name), 'rb').read())['encoding']) as template_file:
+                with open(os.path.join(path, name), 'rb') as f:
+                    encoding = chardet.detect(f.read())['encoding']
+                with codecs.open(os.path.join(path, name), encoding=encoding) as template_file:
                     tpl = ordered_load(template_file.read())
                 tpl['template_name'] = name
 


### PR DESCRIPTION
Fixed an unclosed file warning caused by the fix for #97.