### PR TITLE
Close input files opened by argparse

### DIFF
--- a/invoice2data/main.py
+++ b/invoice2data/main.py
@@ -172,6 +172,7 @@ def main(args=None):
                     date=res['date'].strftime('%Y-%m-%d'),
                     desc=res['desc'])
                 shutil.move(f.name, join(args.move, filename))
+        f.close()
 
     if output_module is not None:
         output_module.write_to_file(output, args.output_name)


### PR DESCRIPTION
Argparse opens input files but does not close them automatically. This generates unclosed file warnings when running the tests.

There are two ways to fix this:

1. Close the file manually
1. Change the argument time from file to string

Either fix is straightforward, but I chose to close the file manually because it is more explicit. I am open to suggestions though.

This should also address #77 