### PR TITLE
Add support for parsing tables

### DIFF
--- a/TUTORIAL.rst
+++ b/TUTORIAL.rst
@@ -149,6 +149,58 @@ and if this one doesn’t match either, this line is ignored. This implies
 that you need to take care that the ``first_line`` regex is the most
 specific one, and ``line`` the least specific.
 
+Tables
+~~~~~
+
+The ``tables`` plugin allows you to parse table-oriented fields that have a row
+of column headers followed by a row of values on the next line. The plugin
+requires a ``start`` and ``end`` regex to identify where the table is located
+in the invoice. The ``body`` regex should contain named capture groups that
+will be added to the fields output. The plugin will attempt to match the
+``body`` regex to the invoice content found between the ``start`` and ``end``
+regexes.
+
+An example invoice that contains table-oriented data may look like:
+
+::
+
+    Guest Name: Sanjay                                                                      Date: 31/12/2017
+
+    Hotel Details                                                   Check In            Check Out       Rooms
+    OYO 4189 Resort Nanganallur,                                    31/12/2017          01/01/2018      1
+    25,Vembuliamman Koil Street,, Pazhavanthangal, Chennai
+                                                                        Booking ID              Payment Mode
+                                                                        IBZY2087                Cash at Hotel
+
+    DESCRIPTION                                             RATE                                    AMOUNT
+
+    Room Charges                                            Rs 1939 x 1 Night x 1 Room              Rs 1939
+
+    Grand Total                                                                                     Rs 1939
+
+    Payment received by OYO                                 Paid through Cash At Hotel (Rs 1939)    Rs 1939
+
+    Balance ( if any )                                                                              Rs 0
+
+The hotel name, check in and check out dates, room count, booking ID, and
+payment mode are all located on different lines from their column headings.
+A template to capture these fields may look like:
+
+::
+
+    tables:
+      - start: Hotel Details\s+Check In\s+Check Out\s+Rooms
+        end: Booking ID
+        body: (?P<hotel_details>[\S ]+),\s+(?P<date_check_in>\d{1,2}\/\d{1,2}\/\d{4})\s+(?P<date_check_out>\d{1,2}\/\d{1,2}\/\d{4})\s+(?P<amount_rooms>\d+)
+      - start: Booking ID\s+Payment Mode
+        end: DESCRIPTION
+        body: (?P<booking_id>\w+)\s+(?P<payment_method>(?:\w+ ?)*)
+
+The plugin supports multiple tables per invoice as seen in the example.
+
+By default, all fields are parsed as strings. The ``tables`` plugin supports
+the ``amount`` and ``date`` field naming conventions to convert data types.
+
 Options
 ~~~~~~~
 

--- a/invoice2data/extract/invoice_template.py
+++ b/invoice2data/extract/invoice_template.py
@@ -11,7 +11,7 @@ import dateparser
 from unidecode import unidecode
 import logging as logger
 from collections import OrderedDict
-from .plugins import lines
+from .plugins import lines, tables
 
 OPTIONS_DEFAULT = {
     'remove_whitespace': False,
@@ -25,7 +25,8 @@ OPTIONS_DEFAULT = {
 }
 
 PLUGIN_MAPPING = {
-    'lines': lines
+    'lines': lines,
+    'tables': tables
 }
 
 class InvoiceTemplate(OrderedDict):

--- a/invoice2data/extract/plugins/tables.py
+++ b/invoice2data/extract/plugins/tables.py
@@ -1,0 +1,61 @@
+"""
+Plugin to extract tables from an invoice.
+"""
+
+import re
+import logging as logger
+
+DEFAULT_OPTIONS = {
+    'field_separator': r'\s+',
+    'line_separator': r'\n',
+}
+
+def extract(self, content, output):
+    """Try to extract tables from an invoice"""
+
+    for table in self['tables']:
+
+        # First apply default options.
+        plugin_settings = DEFAULT_OPTIONS.copy()
+        plugin_settings.update(table)
+        table = plugin_settings
+
+        # Validate settings
+        assert 'start' in table, 'Table start regex missing'
+        assert 'end' in table, 'Table end regex missing'
+        assert 'body' in table, 'Table body regex missing'
+
+        start = re.search(table['start'], content)
+        end = re.search(table['end'], content)
+
+        if not start or not end:
+            logger.warning('no table body found - start %s, end %s', start, end)
+            continue
+
+        table_body = content[start.end():end.start()]
+
+        for line in re.split(table['line_separator'], table_body):
+            # if the line has empty lines in it , skip them
+            if not line.strip('').strip('\n') or not line:
+                continue
+
+            match = re.search(table['body'], line)
+            if match:
+                for field, value in match.groupdict().items():
+                    # If a field name already exists, do not overwrite it
+                    if field in output:
+                        continue
+
+                    if field.startswith('date') or field.endswith('date'):
+                        output[field] = self.parse_date(value)
+                        if not output[field]:
+                            logger.error(
+                                "Date parsing failed on date '%s'", value)
+                            return None
+                    elif field.startswith('amount'):
+                        output[field] = self.parse_number(value)
+                    else:
+                        output[field] = value
+            logger.debug(
+                'ignoring *%s* because it doesn\'t match anything', line
+            )

--- a/invoice2data/extract/templates/com/com.oyo.invoice.yml
+++ b/invoice2data/extract/templates/com/com.oyo.invoice.yml
@@ -1,16 +1,22 @@
 issuer: OYO
 fields:
-  amount: GrandTotalRs(\d+)
-  date: Date:(\d{1,2}\/\d{1,2}\/\d{1,4})
-  invoice_number: ([A-Z0-9]+)CashatHotel
-  payment_method:
-    - \d+(\S*)atHotel
+  amount: Grand Total\s+Rs (\d+)
+  date: Date:\s(\d{1,2}\/\d{1,2}\/\d{1,4})
+  invoice_number: ([A-Z0-9]+)\s+Cash at Hotel
 keywords:
   - OYO
   - Oravel
   - Stays
-
+tables:
+  - start: Hotel Details\s+Check In\s+Check Out\s+Rooms
+    end: Booking ID
+    body: (?P<hotel_details>[\S ]+),\s+(?P<date_check_in>(?:0[1-9]|[12][0-9]|3[01])\/(?:0[1-9]|1[012])\/(?:19\d{2}|20\d{2}))\s+(?P<date_check_out>(?:0[1-9]|[12][0-9]|3[01])\/(?:0[1-9]|1[012])\/(?:19\d{2}|20\d{2}))\s+(?P<amount_rooms>\d+)
+  - start: Booking ID\s+Payment Mode
+    end: DESCRIPTION
+    body: (?P<booking_id>\w+)\s+(?P<payment_method>(?:\w+ ?)*)
+  - start: GSTIN\s+CIN
+    end: Oravel Stays Private Limited
+    body: (?P<gstin>\w+)\s+(?P<cin>\w+)
 options:
   currency: INR
   decimal_separator: '.'
-  remove_whitespace: true

--- a/invoice2data/extract/templates/fr/fr.free.adsl-fiber.yml
+++ b/invoice2data/extract/templates/fr/fr.free.adsl-fiber.yml
@@ -11,6 +11,10 @@ keywords:
   - FR 604 219 388 61
   - Facture
   - EUR
+tables:
+  - start: Numéro de ligne\s+Id\.client\s+Adresse de l’installation
+    end: Facture n°
+    body: (?P<line_number>\w+)\s+(?P<client_id>\d+)\s+[\w ]+
 options:
   currency: EUR
   date_formats:

--- a/invoice2data/test/compare/free_fiber.json
+++ b/invoice2data/test/compare/free_fiber.json
@@ -2,12 +2,14 @@
     {
         "amount": 29.99,
         "amount_untaxed": 24.99,
+        "client_id": "10577874",
         "currency": "EUR",
         "date": "02/07/2015",
         "date_due": "2015-07-05 00:00:00",
         "desc": "Invoice from Free",
         "invoice_number": "562044387",
         "issuer": "Free",
+        "line_number": "FO10479674",
         "vat": "FR60421938861"
     }
 ]

--- a/invoice2data/test/compare/oyo.json
+++ b/invoice2data/test/compare/oyo.json
@@ -1,11 +1,18 @@
 [
     {
         "amount": 1939.0,
+        "amount_rooms": 1.0,
+        "booking_id": "IBZY2087",
+        "cin": "U63090DL2012PTC231770",
         "currency": "INR",
         "date": "31/12/2017",
+        "date_check_in": "2017-12-31 00:00:00",
+        "date_check_out": "2018-01-01 00:00:00",
         "desc": "Invoice from OYO",
+        "gstin": "06AABCO6063D1ZQ",
+        "hotel_details": " OYO 4189 Resort Nanganallur",
         "invoice_number": "IBZY2087",
         "issuer": "OYO",
-        "payment_method": "Cash"
+        "payment_method": "Cash at Hotel"
     }
 ]


### PR DESCRIPTION
It is difficult to parse fields with a regex that do not have an identifying format or string on the same line. This happens when an invoice has "table"-oriented fields with multiple column headings on one line followed by their values on the next line.

The ```test/compare/oyo.pdf``` is a good example. The booking ID and payment mode would be hard to parse because they do not have an obvious identifying format that you can target with a regex. 

```
Booking ID                Payment Mode
IBZY2087                  Cash at Hotel
```

You can match those fields with a regex like ```(?P<booking_id>\w+?)\s+(?P<payment_mode>[\w ]+)``` but there are many other matches too.

The proposed ```tables``` plugin borrows heavily from @hbrunn's ```lines``` plugin. It works by defining ```start``` and ```end``` regexes to target a specific section of the invoice. The ```body``` regex attempts to match against the content between start and end and adds any named capture groups as fields in the output. It supports multiple tables per template and does nothing if there are no tables defined in the template. It follows the ```date``` and ```amount``` type conversion conventions like the core extract function.

I can update the readme and tutorial if you think this is a useful addition.