### PR TITLE
Include invocice number in renamed pdf to avoid duplicated filenames …

### DIFF
--- a/invoice2data/main.py
+++ b/invoice2data/main.py
@@ -169,11 +169,13 @@ def main(args=None):
             if args.copy:
                 filename = FILENAME.format(
                     date=res['date'].strftime('%Y-%m-%d'),
+                    invoice_number=res['invoice_number']),
                     desc=res['desc'])
                 shutil.copyfile(f.name, join(args.copy, filename))
             if args.move:
                 filename = FILENAME.format(
                     date=res['date'].strftime('%Y-%m-%d'),
+                    invoice_number=res['invoice_number']),
                     desc=res['desc'])
                 shutil.move(f.name, join(args.move, filename))
         f.close()


### PR DESCRIPTION
…in copy/move mode

Include invocice number in renamed pdf to avoid duplicated filenames in copy/move mode