### PR TITLE
Improve required fields error message

### DIFF
--- a/invoice2data/extract/invoice_template.py
+++ b/invoice2data/extract/invoice_template.py
@@ -216,5 +216,9 @@ class InvoiceTemplate(OrderedDict):
                 logger.debug(output)
                 return output
         else:
-            logger.error('Unable to match some fields:', output)
+            fields = list(set(output.keys()))
+            logger.error('Unable to match all required fields. '
+                         'The required fields are: {0}. '
+                         'Output contains the following fields: {1}.'
+                         .format(required_fields, fields))
             return None


### PR DESCRIPTION
Log a more detailed error message when required fields are not found. The new message references the list of required fields and the keys in the output dict for quicker debugging.