### PR TITLE
invoice2data Windows os issues

### DIFF
--- a/invoice2data/input/tesseract.py
+++ b/invoice2data/input/tesseract.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+import platform
+
+
 def to_text(path):
     """Wraps Tesseract OCR.
 
@@ -19,12 +22,13 @@ def to_text(path):
     # Check for dependencies. Needs Tesseract and Imagemagick installed.
     if not spawn.find_executable('tesseract'):
         raise EnvironmentError('tesseract not installed.')
-    if not spawn.find_executable('convert'):
+    if not spawn.find_executable('convert'):  # Please remember that on Windows exists C:\Windows\System32\convert.exe and have the same name as ImageMagick tool
         raise EnvironmentError('imagemagick not installed.')
 
+    is_shell_active = platform.system() == "Windows"  # ImageMagick on Windows require shell=True for working
     # convert = "convert -density 350 %s -depth 8 tiff:-" % (path)
     convert = ['convert', '-density', '350', path, '-depth', '8', 'png:-']
-    p1 = subprocess.Popen(convert, stdout=subprocess.PIPE)
+    p1 = subprocess.Popen(convert, stdout=subprocess.PIPE, shell=is_shell_active)
 
     tess = ['tesseract', 'stdin', 'stdout']
     p2 = subprocess.Popen(tess, stdin=p1.stdout, stdout=subprocess.PIPE)

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     url='https://github.com/m3nu/invoice2data',
     description='Python parser to extract data from pdf invoice',
     license="MIT",
-    long_description=open(path.join(path.dirname(__file__), 'README.rst')).read(),
+    long_description=open(path.join(path.dirname(__file__), 'README.rst'), encoding='utf-8').read(),
     package_data = {
         'invoice2data.extract': [
             'templates/com/*.yml',


### PR DESCRIPTION
### invoice2data install not working on not English Windows os eg. Polish:

When you try to run `pip install invoice2data` on not English Windows environment below exception occurred because README.rst contains some utf-8 characters:
```
Collecting invoice2data
  Using cached https://files.pythonhosted.org/packages/1a/af/24b281da1ba7fed86a3a936d5ba5dd531d2b33d57202ccda454d07b84fbb/invoice2data-0.3.2.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "C:\Users\RAFALK~2\AppData\Local\Temp\pip-install-sp5t45qw\invoice2data\setup.py", line 14, in <module>
        long_description=open(path.join(path.dirname(__file__), 'README.rst')).read(),
      File "c:\python\lib\encodings\cp1250.py", line 23, in decode
        return codecs.charmap_decode(input,self.errors,decoding_table)[0]
    UnicodeDecodeError: 'charmap' codec can't decode byte 0x98 in position 5608: character maps to <undefined> 
```

### ImageMagick not working on Windows without active shell

`subprocess.Popen` for ImageMagic is not working on Windows environment when the shell is not active. This is because Windows is operating absolutely different on streams compared to the Unix operating systems.

In addition to above Please remember that on Windows exists `C:\Windows\System32\convert.exe` and have the same name as ImageMagick tool `convert`.
