### PR TITLE
remove unneeded shell flag from tesseract readers

### DIFF
--- a/src/invoice2data/input/tesseract.py
+++ b/src/invoice2data/input/tesseract.py
@@ -26,7 +26,7 @@ def to_text(path):
 
     # convert = "convert -density 350 %s -depth 8 tiff:-" % (path)
     convert = ['convert', '-density', '350', path, '-depth', '8', 'png:-']
-    p1 = subprocess.Popen(convert, stdout=subprocess.PIPE, shell=True)
+    p1 = subprocess.Popen(convert, stdout=subprocess.PIPE)
 
     tess = ['tesseract', 'stdin', 'stdout']
     p2 = subprocess.Popen(tess, stdin=p1.stdout, stdout=subprocess.PIPE)

--- a/src/invoice2data/input/tesseract4.py
+++ b/src/invoice2data/input/tesseract4.py
@@ -57,7 +57,7 @@ def to_text(path, language='fra'):
             'tiff:-',
         ]
 
-        p1 = subprocess.Popen(magick_cmd, stdout=subprocess.PIPE, shell=True)
+        p1 = subprocess.Popen(magick_cmd, stdout=subprocess.PIPE)
 
         tess_cmd = ['tesseract', '-l', language, '--oem', '1', '--psm', '3', 'stdin', 'stdout']
         p2 = subprocess.Popen(tess_cmd, stdin=p1.stdout, stdout=subprocess.PIPE)


### PR DESCRIPTION
This is a breaking pattern on POSIX systems and an unnecessary parameter for Windows according to the subprocess documentation at https://docs.python.org/3.7/library/subprocess.html#subprocess.Popen

I see no obvious reason why this would break anything, but as I do not have a Windows machine, I am unable to confirm 100% if this is working as expected, though. A Windows test would be great. 

This PR closes #220 