### PR TITLE
Fixed one test and used an env var for the google cloud bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Choose any of the following input readers:
 - pdfminer.six `invoice2data --input-reader pdfminer invoice.pdf`
 - pdfplumber `invoice2data --input-reader pdfplumber invoice.pdf`
 - ocrmypdf `invoice2data --input-reader ocrmypdf invoice.pdf`
-- gvision `invoice2data --input-reader gvision invoice.pdf` (needs `GOOGLE_APPLICATION_CREDENTIALS` env var)
+- gvision `invoice2data --input-reader gvision invoice.pdf` (needs `GOOGLE_APPLICATION_CREDENTIALS` env var and a Google Cloud Bucket name. The bucket name can be set as an argument to the function ``to_text`` or as an Environment variable named ``GOOGLE_CLOUD_BUCKET_NAME`` )
 
 Choose any of the following output formats:
 

--- a/tests/test_gvision.py
+++ b/tests/test_gvision.py
@@ -41,7 +41,7 @@ def test_to_text(mocker: "pytest_mock.MockerFixture") -> None:  # type: ignore [
 
     # Call the function
     path = "test.pdf"
-    extracted_text = gvision.to_text(path)
+    extracted_text = gvision.to_text(path, bucket_name="cloud-vision-84893")
 
     # Assertions
     mock_storage_client.return_value.get_bucket.assert_called_once_with(
@@ -77,7 +77,7 @@ def test_to_text_existing_result(mocker: "pytest_mock.MockerFixture") -> None:  
 
     # Call the function
     path = "test.pdf"
-    extracted_text = gvision.to_text(path)
+    extracted_text = gvision.to_text(path, bucket_name="cloud-vision-84893")
 
     # Assertions
     mock_storage_client.return_value.get_bucket.assert_called_once_with(


### PR DESCRIPTION
The bucket name will be given as an environment variable as the method to_text() is only given one argument when used in extract_data().

The fixed test was using the wrong file extension to compare the results. Therefore, the test would not pass.