### PR TITLE
Fix crash on passing -h, -he or any substring of help as an argument.

### DIFF
--- a/src/invoice2data/main.py
+++ b/src/invoice2data/main.py
@@ -121,7 +121,7 @@ def create_parser():
         '--output-date-format',
         dest='output_date_format',
         default="%Y-%m-%d",
-        help='Choose output date format. Default: %Y-%m-%d (ISO 8601 Date)',
+        help='Choose output date format. Default: %%Y-%%m-%%d (ISO 8601 Date)',
     )
 
     parser.add_argument(


### PR DESCRIPTION
When any substring of help was passed as an argument in main menu,
the program raised an exception. It happened as argparse uses '%'
internally to format strings, in order to use %, it need to be
escaped with %.