### PR TITLE
allow reading of text with background by tesseract

### DIFF
--- a/src/invoice2data/input/tesseract.py
+++ b/src/invoice2data/input/tesseract.py
@@ -25,7 +25,7 @@ def to_text(path):
         raise EnvironmentError('imagemagick not installed.')
 
     # convert = "convert -density 350 %s -depth 8 tiff:-" % (path)
-    convert = ['convert', '-density', '350', path, '-depth', '8', 'png:-']
+    convert = ['convert', '-density', '350', path, '-depth', '8', '-alpha', 'off', 'png:-']
     p1 = subprocess.Popen(convert, stdout=subprocess.PIPE)
 
     tess = ['tesseract', 'stdin', 'stdout']


### PR DESCRIPTION
adding the `alpha off` to `convert` allow tesseract to read text with background

pdf used for the tests, (converted to image using `convert -density 350 toTest.pdf toTest.png` for github upload) :
![original](https://user-images.githubusercontent.com/17279801/62200865-8af7dc80-b386-11e9-8bfd-c3b06fb54388.png)


invoice2data debug output before modification :
```
convert-im6.q16: profile 'icc': 'RGB ': RGB color space not permitted on grayscale PNG `/tmp/magick-17KYE8Y-l4QHQt' @ warning/png.c/MagickPNGWarningHandler/1654.
DEBUG:invoice2data.main:START pdftotext result ===========================
DEBUG:invoice2data.main:09 69 w 56 34 (APPEL NON SURTAXE)
URGENCES : 24Hl24 - 7.1/7
COURRIER : VEOLIA EAU - TSA 80122 - 37911 TOURS CEDEX 9

page1/2

   


DEBUG:invoice2data.main:END pdftotext result =============================
DEBUG:invoice2data.main:Testing 3 template files
ERROR:invoice2data.main:No template for docapostRogne.pdf
<type 'module'>
<module 'json' from '/usr/lib/python2.7/json/__init__.pyc'>
```
as you can see the `facture du 29/03/2019` is not read

-----------------------

invoice2data debug output after modification :
```
convert-im6.q16: profile 'icc': 'RGB ': RGB color space not permitted on grayscale PNG `/tmp/magick-33rGvzNtgcs91k' @ warning/png.c/MagickPNGWarningHandler/1654.
DEBUG:invoice2data.main:START pdftotext result ===========================
DEBUG:invoice2data.main:OVEOLIA

09 69 w 56 34 (APPEL NON SURTAXE)
URGENCES : 24Hl24 - 7.1/7
COURRIER : VEOLIA EAU - TSA 80122 - 37911 TOURS CEDEX 9

Factu re
d u 29l03l2019

page1/2


DEBUG:invoice2data.main:END pdftotext result =============================
DEBUG:invoice2data.main:Testing 3 template files
ERROR:invoice2data.main:No template for docapostRogne.pdf
<type 'module'>
<module 'json' from '/usr/lib/python2.7/json/__init__.pyc'>
```
here the `facture du 29/03/2019` is read even if the reading is somewhat not perfect, but this is a tesseract issue

