### PR TITLE
Chunks Plugin

### DIFF
--- a/src/invoice2data/extract/invoice_template.py
+++ b/src/invoice2data/extract/invoice_template.py
@@ -24,7 +24,7 @@ OPTIONS_DEFAULT = {
     "replace": [],  # example: see templates/fr/fr.free.mobile.yml
 }
 
-PLUGIN_MAPPING = {"lines": lines, "tables": tables}
+PLUGIN_MAPPING = {"lines": lines, "tables": tables, "chunks": chunks}
 
 
 class InvoiceTemplate(OrderedDict):

--- a/src/invoice2data/extract/invoice_template.py
+++ b/src/invoice2data/extract/invoice_template.py
@@ -4,100 +4,229 @@ This module abstracts templates for invoice providers.
 Templates are initially read from .yml files and then kept as class.
 """
 
-import os
-import yaml
-import pkg_resources
-from collections import OrderedDict
+import re
+import dateparser
+from unidecode import unidecode
 import logging
-from .invoice_template import InvoiceTemplate
-import codecs
-import chardet
+from collections import OrderedDict
+from .plugins import lines, tables, chunks
 
-logging.getLogger("chardet").setLevel(logging.WARNING)
+logger = logging.getLogger(__name__)
+
+OPTIONS_DEFAULT = {
+    "remove_whitespace": False,
+    "remove_accents": False,
+    "lowercase": False,
+    "currency": "EUR",
+    "date_formats": [],
+    "languages": [],
+    "decimal_separator": ".",
+    "replace": [],  # example: see templates/fr/fr.free.mobile.yml
+}
+
+PLUGIN_MAPPING = {"lines": lines, "tables": tables, "chunks": chunks}
 
 
-# borrowed from http://stackoverflow.com/a/21912744
-def ordered_load(stream, Loader=yaml.Loader, object_pairs_hook=OrderedDict):
-    """load mappings and ordered mappings
-
-    loader to load mappings and ordered mappings into the Python 2.7+ OrderedDict type,
-    instead of the vanilla dict and the list of pairs it currently uses.
+class InvoiceTemplate(OrderedDict):
     """
+    Represents single template files that live as .yml files on the disk.
 
-    class OrderedLoader(Loader):
-        pass
-
-    def construct_mapping(loader, node):
-        loader.flatten_mapping(node)
-        return object_pairs_hook(loader.construct_pairs(node))
-
-    OrderedLoader.add_constructor(
-        yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, construct_mapping
-    )
-
-    return yaml.load(stream, OrderedLoader)
-
-
-def read_templates(folder=None):
-    """
-    Load yaml templates from template folder. Return list of dicts.
-
-    Use built-in templates if no folder is set.
-
-    Parameters
-    ----------
-    folder : str
-        user defined folder where they stores their files, if None uses built-in templates
-
-    Returns
+    Methods
     -------
-    output : Instance of `InvoiceTemplate`
-        template which match based on keywords
-
-    Examples
-    --------
-
-    >>> read_template("home/duskybomb/invoice-templates/")
-    InvoiceTemplate([('issuer', 'OYO'), ('fields', OrderedDict([('amount', 'GrandTotalRs(\\d+)'),
-    ('date', 'Date:(\\d{1,2}\\/\\d{1,2}\\/\\d{1,4})'), ('invoice_number', '([A-Z0-9]+)CashatHotel')])),
-    ('keywords', ['OYO', 'Oravel', 'Stays']), ('options', OrderedDict([('currency', 'INR'), ('decimal_separator', '.'),
-    ('remove_whitespace', True)])), ('template_name', 'com.oyo.invoice.yml')])
-
-    After reading the template you can use the result as an instance of `InvoiceTemplate` to extract fields from
-    `extract_data()`
-
-    >>> my_template = InvoiceTemplate([('issuer', 'OYO'), ('fields', OrderedDict([('amount', 'GrandTotalRs(\\d+)'),
-    ('date', 'Date:(\\d{1,2}\\/\\d{1,2}\\/\\d{1,4})'), ('invoice_number', '([A-Z0-9]+)CashatHotel')])),
-    ('keywords', ['OYO', 'Oravel', 'Stays']), ('options', OrderedDict([('currency', 'INR'), ('decimal_separator', '.'),
-    ('remove_whitespace', True)])), ('template_name', 'com.oyo.invoice.yml')])
-    >>> extract_data(iinvoice2dataNewew, my_template, pdftotext)
-    {'issuer': 'OYO', 'amount': 1939.0, 'date': datetime.datetime(2017, 12, 31, 0, 0), 'invoice_number': 'IBZY2087',
-     'currency': 'INR', 'desc': 'Invoice IBZY2087 from OYO'}
-
+    prepare_input(extracted_str)
+        Input raw string and do transformations, as set in template file.
+    matches_input(optimized_str)
+        See if string matches keywords set in template file
+    parse_number(value)
+        Parse number, remove decimal separator and add other options
+    parse_date(value)
+        Parses date and returns date after parsing
+    coerce_type(value, target_type)
+        change type of values
+    extract(optimized_str)
+        Given a template file and a string, extract matching data fields.
     """
 
-    output = []
+    def __init__(self, *args, **kwargs):
+        super(InvoiceTemplate, self).__init__(*args, **kwargs)
 
-    if folder is None:
-        folder = pkg_resources.resource_filename(__name__, "templates")
+        # Merge template-specific options with defaults
+        self.options = OPTIONS_DEFAULT.copy()
 
-    for path, subdirs, files in os.walk(folder):
-        for name in sorted(files):
-            if name.endswith(".yml"):
-                with open(os.path.join(path, name), "rb") as f:
-                    encoding = chardet.detect(f.read())["encoding"]
-                with codecs.open(
-                    os.path.join(path, name), encoding=encoding
-                ) as template_file:
-                    tpl = ordered_load(template_file.read())
-                tpl["template_name"] = name
+        for lang in self.options["languages"]:
+            assert len(lang) == 2, "lang code must have 2 letters"
 
-                # Test if all required fields are in template:
-                assert "keywords" in tpl.keys(), "Missing keywords field."
+        if "options" in self:
+            self.options.update(self["options"])
 
-                # Keywords as list, if only one.
-                if type(tpl["keywords"]) is not list:
-                    tpl["keywords"] = [tpl["keywords"]]
+        # Set issuer, if it doesn't exist.
+        if "issuer" not in self.keys():
+            self["issuer"] = self["keywords"][0]
 
-                output.append(InvoiceTemplate(tpl))
-    return output
+    def prepare_input(self, extracted_str):
+        """
+        Input raw string and do transformations, as set in template file.
+        """
+
+        # Remove withspace
+        if self.options["remove_whitespace"]:
+            optimized_str = re.sub(" +", "", extracted_str)
+        else:
+            optimized_str = extracted_str
+
+        # Remove accents
+        if self.options["remove_accents"]:
+            optimized_str = unidecode(optimized_str)
+
+        # convert to lower case
+        if self.options["lowercase"]:
+            optimized_str = optimized_str.lower()
+
+        # specific replace
+        for replace in self.options["replace"]:
+            assert len(replace) == 2, "A replace should be a list of 2 items"
+            optimized_str = optimized_str.replace(replace[0], replace[1])
+
+        return optimized_str
+
+    def matches_input(self, optimized_str):
+        """See if string matches keywords set in template file"""
+
+        if all([keyword in optimized_str for keyword in self["keywords"]]):
+            logger.debug("Matched template %s", self["template_name"])
+            return True
+
+    def parse_number(self, value):
+        assert (
+            value.count(self.options["decimal_separator"]) < 2
+        ), "Decimal separator cannot be present several times"
+        # replace decimal separator by a |
+        amount_pipe = value.replace(self.options["decimal_separator"], "|")
+        # remove all possible thousands separators
+        amount_pipe_no_thousand_sep = re.sub(r"[.,\s]", "", amount_pipe)
+        # put dot as decimal sep
+        return float(amount_pipe_no_thousand_sep.replace("|", "."))
+
+    def parse_date(self, value):
+        """Parses date and returns date after parsing"""
+        res = dateparser.parse(
+            value,
+            date_formats=self.options["date_formats"],
+            languages=self.options["languages"],
+        )
+        logger.debug("result of date parsing=%s", res)
+        return res
+
+    def coerce_type(self, value, target_type):
+        if target_type == "int":
+            if not value.strip():
+                return 0
+            return int(self.parse_number(value))
+        elif target_type == "float":
+            if not value.strip():
+                return 0.0
+            return float(self.parse_number(value))
+        elif target_type == "date":
+            return self.parse_date(value)
+        assert False, "Unknown type"
+
+    def extract(self, optimized_str):
+        """
+        Given a template file and a string, extract matching data fields.
+        """
+
+        logger.debug("START optimized_str ========================")
+        logger.debug(optimized_str)
+        logger.debug("END optimized_str ==========================")
+        logger.debug(
+            "Date parsing: languages=%s date_formats=%s",
+            self.options["languages"],
+            self.options["date_formats"],
+        )
+        logger.debug(
+            "Float parsing: decimal separator=%s", self.options["decimal_separator"]
+        )
+        logger.debug("keywords=%s", self["keywords"])
+        logger.debug(self.options)
+
+        # Try to find data for each field.
+        output = {}
+        output["issuer"] = self["issuer"]
+
+        for k, v in self["fields"].items():
+            if k.startswith("static_"):
+                logger.debug("field=%s | static value=%s", k, v)
+                output[k.replace("static_", "")] = v
+            else:
+                logger.debug("field=%s | regexp=%s", k, v)
+
+                sum_field = False
+                if k.startswith("sum_amount") and type(v) is list:
+                    k = k[4:]  # remove 'sum_' prefix
+                    sum_field = True
+                # Fields can have multiple expressions
+                if type(v) is list:
+                    res_find = []
+                    for v_option in v:
+                        res_val = re.findall(v_option, optimized_str)
+                        if res_val:
+                            if sum_field:
+                                res_find += res_val
+                            else:
+                                res_find.extend(res_val)
+                else:
+                    res_find = re.findall(v, optimized_str)
+                if res_find:
+                    logger.debug("res_find=%s", res_find)
+                    if k.startswith("date") or k.endswith("date"):
+                        output[k] = self.parse_date(res_find[0])
+                        if not output[k]:
+                            logger.error(
+                                "Date parsing failed on date '%s'", res_find[0]
+                            )
+                            return None
+                    elif k.startswith("amount"):
+                        if sum_field:
+                            output[k] = 0
+                            for amount_to_parse in res_find:
+                                output[k] += self.parse_number(amount_to_parse)
+                        else:
+                            output[k] = self.parse_number(res_find[0])
+                    else:
+                        res_find = list(set(res_find))
+                        if len(res_find) == 1:
+                            output[k] = res_find[0]
+                        else:
+                            output[k] = res_find
+                else:
+                    logger.warning("regexp for field %s didn't match", k)
+
+        output["currency"] = self.options["currency"]
+
+        # Run plugins:
+        for plugin_keyword, plugin_func in PLUGIN_MAPPING.items():
+            if plugin_keyword in self.keys():
+                plugin_func.extract(self, optimized_str, output)
+
+        # If required fields were found, return output, else log error.
+        if "required_fields" not in self.keys():
+            required_fields = ["date", "amount", "invoice_number", "issuer"]
+        else:
+            required_fields = []
+            for v in self["required_fields"]:
+                required_fields.append(v)
+
+        if set(required_fields).issubset(output.keys()):
+            output["desc"] = "Invoice from %s" % (self["issuer"])
+            logger.debug(output)
+            return output
+        else:
+            fields = list(set(output.keys()))
+            logger.error(
+                "Unable to match all required fields. "
+                "The required fields are: {0}. "
+                "Output contains the following fields: {1}.".format(
+                    required_fields, fields
+                )
+            )
+            return None

--- a/src/invoice2data/extract/invoice_template.py
+++ b/src/invoice2data/extract/invoice_template.py
@@ -4,229 +4,100 @@ This module abstracts templates for invoice providers.
 Templates are initially read from .yml files and then kept as class.
 """
 
-import re
-import dateparser
-from unidecode import unidecode
-import logging
+import os
+import yaml
+import pkg_resources
 from collections import OrderedDict
-from .plugins import lines, tables
+import logging
+from .invoice_template import InvoiceTemplate
+import codecs
+import chardet
 
-logger = logging.getLogger(__name__)
-
-OPTIONS_DEFAULT = {
-    "remove_whitespace": False,
-    "remove_accents": False,
-    "lowercase": False,
-    "currency": "EUR",
-    "date_formats": [],
-    "languages": [],
-    "decimal_separator": ".",
-    "replace": [],  # example: see templates/fr/fr.free.mobile.yml
-}
-
-PLUGIN_MAPPING = {"lines": lines, "tables": tables, "chunks": chunks}
+logging.getLogger("chardet").setLevel(logging.WARNING)
 
 
-class InvoiceTemplate(OrderedDict):
+# borrowed from http://stackoverflow.com/a/21912744
+def ordered_load(stream, Loader=yaml.Loader, object_pairs_hook=OrderedDict):
+    """load mappings and ordered mappings
+
+    loader to load mappings and ordered mappings into the Python 2.7+ OrderedDict type,
+    instead of the vanilla dict and the list of pairs it currently uses.
     """
-    Represents single template files that live as .yml files on the disk.
 
-    Methods
+    class OrderedLoader(Loader):
+        pass
+
+    def construct_mapping(loader, node):
+        loader.flatten_mapping(node)
+        return object_pairs_hook(loader.construct_pairs(node))
+
+    OrderedLoader.add_constructor(
+        yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, construct_mapping
+    )
+
+    return yaml.load(stream, OrderedLoader)
+
+
+def read_templates(folder=None):
+    """
+    Load yaml templates from template folder. Return list of dicts.
+
+    Use built-in templates if no folder is set.
+
+    Parameters
+    ----------
+    folder : str
+        user defined folder where they stores their files, if None uses built-in templates
+
+    Returns
     -------
-    prepare_input(extracted_str)
-        Input raw string and do transformations, as set in template file.
-    matches_input(optimized_str)
-        See if string matches keywords set in template file
-    parse_number(value)
-        Parse number, remove decimal separator and add other options
-    parse_date(value)
-        Parses date and returns date after parsing
-    coerce_type(value, target_type)
-        change type of values
-    extract(optimized_str)
-        Given a template file and a string, extract matching data fields.
+    output : Instance of `InvoiceTemplate`
+        template which match based on keywords
+
+    Examples
+    --------
+
+    >>> read_template("home/duskybomb/invoice-templates/")
+    InvoiceTemplate([('issuer', 'OYO'), ('fields', OrderedDict([('amount', 'GrandTotalRs(\\d+)'),
+    ('date', 'Date:(\\d{1,2}\\/\\d{1,2}\\/\\d{1,4})'), ('invoice_number', '([A-Z0-9]+)CashatHotel')])),
+    ('keywords', ['OYO', 'Oravel', 'Stays']), ('options', OrderedDict([('currency', 'INR'), ('decimal_separator', '.'),
+    ('remove_whitespace', True)])), ('template_name', 'com.oyo.invoice.yml')])
+
+    After reading the template you can use the result as an instance of `InvoiceTemplate` to extract fields from
+    `extract_data()`
+
+    >>> my_template = InvoiceTemplate([('issuer', 'OYO'), ('fields', OrderedDict([('amount', 'GrandTotalRs(\\d+)'),
+    ('date', 'Date:(\\d{1,2}\\/\\d{1,2}\\/\\d{1,4})'), ('invoice_number', '([A-Z0-9]+)CashatHotel')])),
+    ('keywords', ['OYO', 'Oravel', 'Stays']), ('options', OrderedDict([('currency', 'INR'), ('decimal_separator', '.'),
+    ('remove_whitespace', True)])), ('template_name', 'com.oyo.invoice.yml')])
+    >>> extract_data(iinvoice2dataNewew, my_template, pdftotext)
+    {'issuer': 'OYO', 'amount': 1939.0, 'date': datetime.datetime(2017, 12, 31, 0, 0), 'invoice_number': 'IBZY2087',
+     'currency': 'INR', 'desc': 'Invoice IBZY2087 from OYO'}
+
     """
 
-    def __init__(self, *args, **kwargs):
-        super(InvoiceTemplate, self).__init__(*args, **kwargs)
+    output = []
 
-        # Merge template-specific options with defaults
-        self.options = OPTIONS_DEFAULT.copy()
+    if folder is None:
+        folder = pkg_resources.resource_filename(__name__, "templates")
 
-        for lang in self.options["languages"]:
-            assert len(lang) == 2, "lang code must have 2 letters"
+    for path, subdirs, files in os.walk(folder):
+        for name in sorted(files):
+            if name.endswith(".yml"):
+                with open(os.path.join(path, name), "rb") as f:
+                    encoding = chardet.detect(f.read())["encoding"]
+                with codecs.open(
+                    os.path.join(path, name), encoding=encoding
+                ) as template_file:
+                    tpl = ordered_load(template_file.read())
+                tpl["template_name"] = name
 
-        if "options" in self:
-            self.options.update(self["options"])
+                # Test if all required fields are in template:
+                assert "keywords" in tpl.keys(), "Missing keywords field."
 
-        # Set issuer, if it doesn't exist.
-        if "issuer" not in self.keys():
-            self["issuer"] = self["keywords"][0]
+                # Keywords as list, if only one.
+                if type(tpl["keywords"]) is not list:
+                    tpl["keywords"] = [tpl["keywords"]]
 
-    def prepare_input(self, extracted_str):
-        """
-        Input raw string and do transformations, as set in template file.
-        """
-
-        # Remove withspace
-        if self.options["remove_whitespace"]:
-            optimized_str = re.sub(" +", "", extracted_str)
-        else:
-            optimized_str = extracted_str
-
-        # Remove accents
-        if self.options["remove_accents"]:
-            optimized_str = unidecode(optimized_str)
-
-        # convert to lower case
-        if self.options["lowercase"]:
-            optimized_str = optimized_str.lower()
-
-        # specific replace
-        for replace in self.options["replace"]:
-            assert len(replace) == 2, "A replace should be a list of 2 items"
-            optimized_str = optimized_str.replace(replace[0], replace[1])
-
-        return optimized_str
-
-    def matches_input(self, optimized_str):
-        """See if string matches keywords set in template file"""
-
-        if all([keyword in optimized_str for keyword in self["keywords"]]):
-            logger.debug("Matched template %s", self["template_name"])
-            return True
-
-    def parse_number(self, value):
-        assert (
-            value.count(self.options["decimal_separator"]) < 2
-        ), "Decimal separator cannot be present several times"
-        # replace decimal separator by a |
-        amount_pipe = value.replace(self.options["decimal_separator"], "|")
-        # remove all possible thousands separators
-        amount_pipe_no_thousand_sep = re.sub(r"[.,\s]", "", amount_pipe)
-        # put dot as decimal sep
-        return float(amount_pipe_no_thousand_sep.replace("|", "."))
-
-    def parse_date(self, value):
-        """Parses date and returns date after parsing"""
-        res = dateparser.parse(
-            value,
-            date_formats=self.options["date_formats"],
-            languages=self.options["languages"],
-        )
-        logger.debug("result of date parsing=%s", res)
-        return res
-
-    def coerce_type(self, value, target_type):
-        if target_type == "int":
-            if not value.strip():
-                return 0
-            return int(self.parse_number(value))
-        elif target_type == "float":
-            if not value.strip():
-                return 0.0
-            return float(self.parse_number(value))
-        elif target_type == "date":
-            return self.parse_date(value)
-        assert False, "Unknown type"
-
-    def extract(self, optimized_str):
-        """
-        Given a template file and a string, extract matching data fields.
-        """
-
-        logger.debug("START optimized_str ========================")
-        logger.debug(optimized_str)
-        logger.debug("END optimized_str ==========================")
-        logger.debug(
-            "Date parsing: languages=%s date_formats=%s",
-            self.options["languages"],
-            self.options["date_formats"],
-        )
-        logger.debug(
-            "Float parsing: decimal separator=%s", self.options["decimal_separator"]
-        )
-        logger.debug("keywords=%s", self["keywords"])
-        logger.debug(self.options)
-
-        # Try to find data for each field.
-        output = {}
-        output["issuer"] = self["issuer"]
-
-        for k, v in self["fields"].items():
-            if k.startswith("static_"):
-                logger.debug("field=%s | static value=%s", k, v)
-                output[k.replace("static_", "")] = v
-            else:
-                logger.debug("field=%s | regexp=%s", k, v)
-
-                sum_field = False
-                if k.startswith("sum_amount") and type(v) is list:
-                    k = k[4:]  # remove 'sum_' prefix
-                    sum_field = True
-                # Fields can have multiple expressions
-                if type(v) is list:
-                    res_find = []
-                    for v_option in v:
-                        res_val = re.findall(v_option, optimized_str)
-                        if res_val:
-                            if sum_field:
-                                res_find += res_val
-                            else:
-                                res_find.extend(res_val)
-                else:
-                    res_find = re.findall(v, optimized_str)
-                if res_find:
-                    logger.debug("res_find=%s", res_find)
-                    if k.startswith("date") or k.endswith("date"):
-                        output[k] = self.parse_date(res_find[0])
-                        if not output[k]:
-                            logger.error(
-                                "Date parsing failed on date '%s'", res_find[0]
-                            )
-                            return None
-                    elif k.startswith("amount"):
-                        if sum_field:
-                            output[k] = 0
-                            for amount_to_parse in res_find:
-                                output[k] += self.parse_number(amount_to_parse)
-                        else:
-                            output[k] = self.parse_number(res_find[0])
-                    else:
-                        res_find = list(set(res_find))
-                        if len(res_find) == 1:
-                            output[k] = res_find[0]
-                        else:
-                            output[k] = res_find
-                else:
-                    logger.warning("regexp for field %s didn't match", k)
-
-        output["currency"] = self.options["currency"]
-
-        # Run plugins:
-        for plugin_keyword, plugin_func in PLUGIN_MAPPING.items():
-            if plugin_keyword in self.keys():
-                plugin_func.extract(self, optimized_str, output)
-
-        # If required fields were found, return output, else log error.
-        if "required_fields" not in self.keys():
-            required_fields = ["date", "amount", "invoice_number", "issuer"]
-        else:
-            required_fields = []
-            for v in self["required_fields"]:
-                required_fields.append(v)
-
-        if set(required_fields).issubset(output.keys()):
-            output["desc"] = "Invoice from %s" % (self["issuer"])
-            logger.debug(output)
-            return output
-        else:
-            fields = list(set(output.keys()))
-            logger.error(
-                "Unable to match all required fields. "
-                "The required fields are: {0}. "
-                "Output contains the following fields: {1}.".format(
-                    required_fields, fields
-                )
-            )
-            return None
+                output.append(InvoiceTemplate(tpl))
+    return output

--- a/src/invoice2data/extract/loader.py
+++ b/src/invoice2data/extract/loader.py
@@ -70,7 +70,7 @@ def read_templates(folder=None):
     ('date', 'Date:(\\d{1,2}\\/\\d{1,2}\\/\\d{1,4})'), ('invoice_number', '([A-Z0-9]+)CashatHotel')])),
     ('keywords', ['OYO', 'Oravel', 'Stays']), ('options', OrderedDict([('currency', 'INR'), ('decimal_separator', '.'),
     ('remove_whitespace', True)])), ('template_name', 'com.oyo.invoice.yml')])
-    >>> extract_data("invoice2data/test/pdfs/oyo.pdf", my_template, pdftotext)
+    >>> extract_data(iinvoice2dataNewew, my_template, pdftotext)
     {'issuer': 'OYO', 'amount': 1939.0, 'date': datetime.datetime(2017, 12, 31, 0, 0), 'invoice_number': 'IBZY2087',
      'currency': 'INR', 'desc': 'Invoice IBZY2087 from OYO'}
 

--- a/src/invoice2data/extract/plugins/chunks.py
+++ b/src/invoice2data/extract/plugins/chunks.py
@@ -1,0 +1,62 @@
+"""
+Plugin to extract chunks of lines from an invoice.
+
+Worked on by Sam Slater
+"""
+
+import re
+import logging as logger
+
+DEFAULT_OPTIONS = {'field_separator': r'\s+', 'line_separator': r'\n'}
+
+
+def extract(self, content, output):
+    """Try to extract Chunk from the invoice"""
+    chunks = []
+    for chunk in self['chunks']:
+        # First apply default options.
+        plugin_settings = DEFAULT_OPTIONS.copy()
+        plugin_settings.update(chunk)
+        chunk = plugin_settings
+
+        # Validate settings
+        assert 'chunk' in chunk, 'Chunk regex missing'
+
+        start = re.search(chunk['start'], content) if 'start' in chunk.keys() else None
+        end = re.search(chunk['end'], content) if 'end' in chunk.keys() else None
+
+        content_section = content
+        # refine content section if start and end have been declared.
+        if start and end:
+            content_section = content[start.end(): end.start()]
+        looping = True
+        if 'chunk_start' in chunk and 'chunk_end' in chunk:
+            chunk_start = re.search(chunk['chunk_start'], content_section)
+            chunk_end = re.search(chunk['chunk_end'], content_section)
+            if chunk_start is None or chunk_end is None:
+                logger.debug("Chunk start and end cannot be found")
+                looping = False
+            while looping:
+                filtered_chunk = content_section[chunk_start.end(): chunk_end.start()]
+                logger.debug("Line content is - " + filtered_chunk)
+                found_content = re.search(chunk['chunk'], filtered_chunk)
+                # if content has been found add it to the output otherwise stop the loop
+                if found_content:
+                    content = {
+                        field: value.strip() if value else ''
+                        for field, value in found_content.groupdict().items()
+                    }
+                    chunks.append(content)
+                    content_section = content_section[chunk_end.end():len(content_section) - 1]
+                    # stop the loop if 'repeat' is not specified or not equal to True
+                    if "False" == chunk.get('repeat', "False"):
+                        looping = False
+                else:
+                    looping = False
+        types = chunk.get('types', [])
+        for row in chunks:
+            for name in row.keys():
+                if name in types:
+                    row[name] = self.coerce_type(row[name], types[name])
+        if chunks:
+            output['chunks'] = chunks

--- a/src/invoice2data/extract/plugins/chunks.py
+++ b/src/invoice2data/extract/plugins/chunks.py
@@ -20,7 +20,9 @@ def extract(self, content, output):
         chunk = plugin_settings
 
         # Validate settings
-        assert 'chunk' in chunk, 'Chunk regex missing'
+        assert 'chunk' in chunk, 'chunk regex missing'
+        assert 'chunk_start' in chunk, 'chunk_start regex missing'
+        assert 'chunk_end' in chunk, 'chunk_end regex missing'
 
         start = re.search(chunk['start'], content) if 'start' in chunk.keys() else None
         end = re.search(chunk['end'], content) if 'end' in chunk.keys() else None

--- a/src/invoice2data/extract/plugins/chunks.py
+++ b/src/invoice2data/extract/plugins/chunks.py
@@ -20,9 +20,7 @@ def extract(self, content, output):
         chunk = plugin_settings
 
         # Validate settings
-        assert 'chunk' in chunk, 'chunk regex missing'
-        assert 'chunk_start' in chunk, 'chunk_start regex missing'
-        assert 'chunk_end' in chunk, 'chunk_end regex missing'
+        assert 'chunk' in chunk, 'Chunk regex missing'
 
         start = re.search(chunk['start'], content) if 'start' in chunk.keys() else None
         end = re.search(chunk['end'], content) if 'end' in chunk.keys() else None
@@ -32,6 +30,7 @@ def extract(self, content, output):
         if start and end:
             content_section = content[start.end(): end.start()]
         looping = True
+        logger.debug("STARTING CHUNKS")
         if 'chunk_start' in chunk and 'chunk_end' in chunk:
             chunk_start = re.search(chunk['chunk_start'], content_section)
             chunk_end = re.search(chunk['chunk_end'], content_section)

--- a/src/invoice2data/extract/plugins/lines.py
+++ b/src/invoice2data/extract/plugins/lines.py
@@ -5,85 +5,86 @@ Initial work and maintenance by Holger Brunn @hbrunn
 """
 
 import re
-import logging
+import logging as logger
 
-logger = logging.getLogger(__name__)
-
-DEFAULT_OPTIONS = {"field_separator": r"\s+", "line_separator": r"\n"}
+DEFAULT_OPTIONS = {'field_separator': r'\s+', 'line_separator': r'\n'}
 
 
 def extract(self, content, output):
     """Try to extract lines from the invoice"""
-
-    # First apply default options.
-    plugin_settings = DEFAULT_OPTIONS.copy()
-    plugin_settings.update(self["lines"])
-    self["lines"] = plugin_settings
-
-    # Validate settings
-    assert "start" in self["lines"], "Lines start regex missing"
-    assert "end" in self["lines"], "Lines end regex missing"
-    assert "line" in self["lines"], "Line regex missing"
-
-    start = re.search(self["lines"]["start"], content)
-    end = re.search(self["lines"]["end"], content)
-    if not start or not end:
-        logger.warning("no lines found - start %s, end %s", start, end)
-        return
-    content = content[start.end() : end.start()]
     lines = []
-    current_row = {}
-    if "first_line" not in self["lines"] and "last_line" not in self["lines"]:
-        self["lines"]["first_line"] = self["lines"]["line"]
-    for line in re.split(self["lines"]["line_separator"], content):
-        # if the line has empty lines in it , skip them
-        if not line.strip("").strip("\n") or not line:
-            continue
-        if "first_line" in self["lines"]:
-            match = re.search(self["lines"]["first_line"], line)
-            if match:
-                if "last_line" not in self["lines"]:
+    logger.debug("STARTING LINES")
+    for line in self['lines']:
+        # First apply default options.
+        plugin_settings = DEFAULT_OPTIONS.copy()
+        plugin_settings.update(line)
+        line = plugin_settings
+
+        # Validate settings
+        assert 'start' in line, 'Lines start regex missing'
+        assert 'end' in line, 'Lines end regex missing'
+        assert 'line' in line, 'Line regex missing'
+
+        start = re.search(line['start'], content)
+        end = re.search(line['end'], content)
+        if not start or not end:
+            logger.warning('no lines found - start %s, end %s', start, end)
+            return
+        content_section = content[start.end(): end.start()]
+        current_row = {}
+        if 'first_line' not in line and 'last_line' not in line:
+            line['first_line'] = line['line']
+
+        for line_content in re.split(line['line_separator'], content_section):
+
+            # if the line has empty lines in it , skip them
+            if not line_content.strip('').strip('\n') or not line_content:
+                continue
+            if 'first_line' in line:
+                match = re.search(line['first_line'], line_content)
+                if match:
+                    if 'last_line' not in line:
+                        if current_row:
+                            lines.append(current_row)
+                        current_row = {}
+                    if current_row:
+                        lines.append(current_row)
+                    current_row = {
+                        field: value.strip() if value else ''
+                        for field, value in match.groupdict().items()
+                    }
+                    continue
+            if 'last_line' in line:
+                match = re.search(line['last_line'], line_content)
+                if match:
+                    for field, value in match.groupdict().items():
+                        current_row[field] = '%s%s%s' % (
+                            current_row.get(field, ''),
+                            current_row.get(field, '') and '\n' or '',
+                            value.strip() if value else '',
+                        )
                     if current_row:
                         lines.append(current_row)
                     current_row = {}
-                if current_row:
-                    lines.append(current_row)
-                current_row = {
-                    field: value.strip() if value else ""
-                    for field, value in match.groupdict().items()
-                }
-                continue
-        if "last_line" in self["lines"]:
-            match = re.search(self["lines"]["last_line"], line)
+                    continue
+            match = re.search(line['line'], line_content)
             if match:
                 for field, value in match.groupdict().items():
-                    current_row[field] = "%s%s%s" % (
-                        current_row.get(field, ""),
-                        current_row.get(field, "") and "\n" or "",
-                        value.strip() if value else "",
+                    current_row[field] = '%s%s%s' % (
+                        current_row.get(field, ''),
+                        current_row.get(field, '') and '\n' or '',
+                        value.strip() if value else '',
                     )
-                if current_row:
-                    lines.append(current_row)
-                current_row = {}
                 continue
-        match = re.search(self["lines"]["line"], line)
-        if match:
-            for field, value in match.groupdict().items():
-                current_row[field] = "%s%s%s" % (
-                    current_row.get(field, ""),
-                    current_row.get(field, "") and "\n" or "",
-                    value.strip() if value else "",
-                )
-            continue
-        logger.debug("ignoring *%s* because it doesn't match anything", line)
-    if current_row:
-        lines.append(current_row)
+            logger.debug('ignoring *%s* because it doesn\'t match anything', line_content)
+        if current_row:
+            lines.append(current_row)
 
-    types = self["lines"].get("types", [])
-    for row in lines:
-        for name in row.keys():
-            if name in types:
-                row[name] = self.coerce_type(row[name], types[name])
+        types = line.get('types', [])
+        for row in lines:
+            for name in row.keys():
+                if name in types:
+                    row[name] = self.coerce_type(row[name], types[name])
 
-    if lines:
-        output["lines"] = lines
+        if lines:
+            output['lines'] = lines

--- a/src/invoice2data/input/gvision.py
+++ b/src/invoice2data/input/gvision.py
@@ -2,7 +2,7 @@
 def to_text(path, bucket_name="cloud-vision-84893", language="fr"):
     """Sends PDF files to Google Cloud Vision for OCR.
 
-    Before using invoice2data, make sure you have the auth json path set as
+    Before using invoice2dataNew, make sure you have the auth json path set as
     env var GOOGLE_APPLICATION_CREDENTIALS
 
     Parameters

--- a/src/invoice2data/main.py
+++ b/src/invoice2data/main.py
@@ -58,7 +58,7 @@ def extract_data(invoicefile, templates=None, input_module=pdftotext):
 
     Notes
     -----
-    Import required `input_module` when using invoice2data as a library
+    Import required `input_module` when using invoice2dataNew as a library
 
     See Also
     --------
@@ -67,10 +67,10 @@ def extract_data(invoicefile, templates=None, input_module=pdftotext):
 
     Examples
     --------
-    When using `invoice2data` as an library
+    When using `invoice2dataNew` as an library
 
-    >>> from invoice2data.input import pdftotext
-    >>> extract_data("invoice2data/test/pdfs/oyo.pdf", None, pdftotext)
+    >>> from invoice2dataNew.input import pdftotext
+    >>> extract_data("invoice2dataNew/test/pdfs/oyo.pdf", None, pdftotext)
     {'issuer': 'OYO', 'amount': 1939.0, 'date': datetime.datetime(2017, 12, 31, 0, 0), 'invoice_number': 'IBZY2087',
      'currency': 'INR', 'desc': 'Invoice IBZY2087 from OYO'}
 

--- a/src/invoice2data/output/to_csv.py
+++ b/src/invoice2data/output/to_csv.py
@@ -22,7 +22,7 @@ def write_to_file(data, path, date_format="%Y-%m-%d"):
 
     Examples
     --------
-        >>> from invoice2data.output import to_csv
+        >>> from invoice2dataNew.output import to_csv
         >>> to_csv.write_to_file(data, "/exported_csv/invoice.csv")
         >>> to_csv.write_to_file(data, "invoice.csv")
 

--- a/src/invoice2data/output/to_json.py
+++ b/src/invoice2data/output/to_json.py
@@ -29,7 +29,7 @@ def write_to_file(data, path, date_format="%Y-%m-%d"):
 
     Examples
     --------
-        >>> from invoice2data.output import to_json
+        >>> from invoice2dataNew.output import to_json
         >>> to_json.write_to_file(data, "/exported_json/invoice.json")
         >>> to_json.write_to_file(data, "invoice.json")
 

--- a/src/invoice2data/output/to_xml.py
+++ b/src/invoice2data/output/to_xml.py
@@ -30,7 +30,7 @@ def write_to_file(data, path, date_format="%Y-%m-%d"):
 
     Examples
     --------
-        >>> from invoice2data.output import to_xml
+        >>> from invoice2dataNew.output import to_xml
         >>> to_xml.write_to_file(data, "/exported_xml/invoice.xml")
         >>> to_xml.write_to_file(data, "invoice.xml")
 


### PR DESCRIPTION
Chunks Plugin

more specific multi-lined version of lines.

- "start" and "end" declares the global section where all chunks will be in (Not mandatory. if not stated then uses whole invoice text)

-"chunk_start" and "chunk_end" similar to "start" and "end" but defines the start and end of the single or repeating chunk, e.g start of each meter reading in an invoice (Mandatory)

- "chunk" similar to the "line" key in the lines plugin but allows for multi-line regex expressions (Mandatory)

-"repeat" loops through the content to find every chunk that matches (Not mandatory - defaults to "False")