### PR TITLE
Update tesseract.py for windows users

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,8 @@ jobs:
 #     docker:
 #     - image: circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
 #       command: /sbin/init
-    machine: true
+    machine:
+      image: ubuntu-1604:201903-01
     steps:
     # Machine Setup
     #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
@@ -29,7 +30,7 @@ jobs:
         keys:
         # This branch if available
         - v1-dep-{{ .Branch }}-
-    - run: sudo apt-get update && sudo apt-get install tesseract-ocr xpdf
+    - run: sudo apt-get update && sudo apt-get install tesseract-ocr xpdf imagemagick
     - run: cd /opt/circleci/.pyenv/plugins/python-build/../.. && git pull && cd -
     - run: pyenv install -s 2.7.14
     - run: pyenv install -s 3.5.4

--- a/src/invoice2data/input/tesseract.py
+++ b/src/invoice2data/input/tesseract.py
@@ -21,11 +21,12 @@ def to_text(path):
     # Check for dependencies. Needs Tesseract and Imagemagick installed.
     if not spawn.find_executable("tesseract"):
         raise EnvironmentError("tesseract not installed.")
-    if not spawn.find_executable("convert"):
+    if not spawn.find_executable("magick"):
         raise EnvironmentError("imagemagick not installed.")
 
-    # convert = "convert -density 350 %s -depth 8 tiff:-" % (path)
+    # convert = "magick convert -density 350 %s -depth 8 tiff:-" % (path)
     convert = [
+        "magick",
         "convert",
         "-density",
         "350",


### PR DESCRIPTION
Update tesseract.py for windows users to avoid conflict with the build-in 'convert' command. Fort imagemagick the command is now 'magick convert' rather than 'convert' only.