### PR TITLE
extract_data input_module kwarg accepts strings

### DIFF
--- a/src/invoice2data/main.py
+++ b/src/invoice2data/main.py
@@ -33,7 +33,7 @@ input_mapping = {
 output_mapping = {"csv": to_csv, "json": to_json, "xml": to_xml, "none": None}
 
 
-def extract_data(invoicefile, templates=None, input_module=pdftotext):
+def extract_data(invoicefile, templates=None, input_module='pdftotext'):
     """Extracts structured data from PDF/image invoices.
 
     This function uses the text extracted from a PDF file or image and
@@ -75,6 +75,8 @@ def extract_data(invoicefile, templates=None, input_module=pdftotext):
      'currency': 'INR', 'desc': 'Invoice IBZY2087 from OYO'}
 
     """
+    if type(input_module) == str:
+        input_module = input_mapping[input_module]
     if templates is None:
         templates = read_templates()
 


### PR DESCRIPTION
I think it makes sense to modify `extract_data` to accept strings as the canonical `input_module` kwarg, as it saves the user from having to instantiate their own `input_module`. (Especially because we have the nice `input_mapping` dict just a few lines earlier!) This change would default the `input_module` kwarg to a string, but still maintain the legacy API because of the `if` clause on line 78 of my fork.