### PR TITLE
Update to match current PDF Miner Version

### DIFF
--- a/src/invoice2data/input/pdfminer_wrapper.py
+++ b/src/invoice2data/input/pdfminer_wrapper.py
@@ -31,10 +31,9 @@ def to_text(path):
 
     rsrcmgr = PDFResourceManager()
     retstr = StringIO()
-    codec = "utf-8"
     laparams = LAParams()
     laparams.all_texts = True
-    device = TextConverter(rsrcmgr, retstr, codec=codec, laparams=laparams)
+    device = TextConverter(rsrcmgr, retstr, laparams=laparams)
     with open(path, "rb") as fp:
         interpreter = PDFPageInterpreter(rsrcmgr, device)
         password = ""


### PR DESCRIPTION
The current PDF Miner Version 20191103 (https://github.com/euske/pdfminer/tree/master/pdfminer) doesn't support codec setting.