### PR TITLE
Allow setting custom lines join separator

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -157,6 +157,7 @@ Example:
         first_line: ^    (?P<description>\w+.*)\$(?P<price_unit>\d+\.\d+)
         line: (.*)\$(\d+\.\d+)
         last_line: VAT \*\*
+        lines_join: " "
 
 Development
 -----------

--- a/src/invoice2data/extract/plugins/lines.py
+++ b/src/invoice2data/extract/plugins/lines.py
@@ -9,7 +9,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_OPTIONS = {"field_separator": r"\s+", "line_separator": r"\n"}
+DEFAULT_OPTIONS = {"field_separator": r"\s+", "line_separator": r"\n", "lines_join": "\n"}
 
 
 def extract(self, content, output):
@@ -59,7 +59,7 @@ def extract(self, content, output):
                 for field, value in match.groupdict().items():
                     current_row[field] = "%s%s%s" % (
                         current_row.get(field, ""),
-                        current_row.get(field, "") and "\n" or "",
+                        current_row.get(field, "") and self["lines"]["lines_join"] or "",
                         value.strip() if value else "",
                     )
                 if current_row:
@@ -71,7 +71,7 @@ def extract(self, content, output):
             for field, value in match.groupdict().items():
                 current_row[field] = "%s%s%s" % (
                     current_row.get(field, ""),
-                    current_row.get(field, "") and "\n" or "",
+                    current_row.get(field, "") and self["lines"]["lines_join"] or "",
                     value.strip() if value else "",
                 )
             continue


### PR DESCRIPTION
```
Replace hardcoded "\n" with plugin option. It allows specifying custom
separator in template and e.g. joining lines with a space.

Signed-off-by: Rafał Miłecki <rafal@milecki.pl>
```