### PR TITLE
Export all data to XML format

### DIFF
--- a/src/invoice2data/output/to_xml.py
+++ b/src/invoice2data/output/to_xml.py
@@ -1,4 +1,5 @@
 import xml.etree.ElementTree as ET
+import datetime
 from xml.dom import minidom
 
 
@@ -7,6 +8,21 @@ def prettify(elem):
     rough_string = ET.tostring(elem, "utf-8")
     reparsed = minidom.parseString(rough_string)
     return reparsed.toprettyxml(indent="  ")
+
+
+def dict_to_tags(parent, data, date_format):
+    for k, v in data.items():
+        tag = ET.SubElement(parent, k)
+        if isinstance(v, str):
+            tag.text = v
+        elif isinstance(v, int) or isinstance(v, float):
+            tag.text = str(v)
+        elif isinstance(v, datetime.date):
+            tag.text = v.strftime(date_format)
+        elif isinstance(v, list):
+            for e in v:
+                item = ET.SubElement(tag, "item")
+                dict_to_tags(item, e, date_format)
 
 
 def write_to_file(data, path, date_format="%Y-%m-%d"):
@@ -26,7 +42,6 @@ def write_to_file(data, path, date_format="%Y-%m-%d"):
     Notes
     ----
     Do give file name to the function parameter path.
-    Only `date`, `desc`, `amount` and `currency` are exported
 
     Examples
     --------
@@ -47,15 +62,8 @@ def write_to_file(data, path, date_format="%Y-%m-%d"):
     for line in data:
         i += 1
         tag_item = ET.SubElement(tag_data, "item")
-        tag_date = ET.SubElement(tag_item, "date")
-        tag_desc = ET.SubElement(tag_item, "desc")
-        tag_currency = ET.SubElement(tag_item, "currency")
-        tag_amount = ET.SubElement(tag_item, "amount")
         tag_item.set("id", str(i))
-        tag_date.text = line["date"].strftime(date_format)
-        tag_desc.text = line["desc"]
-        tag_currency.text = line["currency"]
-        tag_amount.text = str(line["amount"])
+        dict_to_tags(tag_item, line, date_format)
 
     xml_file.write(prettify(tag_data))
     xml_file.close()


### PR DESCRIPTION
```
Export everything (including lines) instead of 4 predefined fields so
XML can be fully used.

Before:
<?xml version="1.0" ?>
<data>
  <item id="1">
    <date>2020-04-15</date>
    <desc>Invoice from Foo company</desc>
    <currency>PLN</currency>
    <amount>123.45</amount>
  </item>
</data>

After:
<?xml version="1.0" ?>
<data>
  <item id="1">
    <issuer>Foo company</issuer>
    <amount>123.45</amount>
    <date>2020-04-15</date>
    <invoice_number>1234</invoice_number>
    <currency>PLN</currency>
    <lines>
      <item>
        <pos>1</pos>
        <name>Bread</name>
        <qty>5</qty>
      </item>
      <item>
        <pos>2</pos>
        <name>Milk</name>
        <qty>10</qty>
      </item>
    </lines>
    <desc>Invoice from Foo company</desc>
  </item>
</data>

Signed-off-by: Rafał Miłecki <rafal@milecki.pl>
```