### PR TITLE
Completed the XML File Export

### DIFF
--- a/src/invoice2data/extract/invoice_template.py
+++ b/src/invoice2data/extract/invoice_template.py
@@ -70,7 +70,7 @@ class InvoiceTemplate(OrderedDict):
 
         # Remove withspace
         if self.options["remove_whitespace"]:
-            optimized_str = re.sub(" +", "", extracted_str)
+            optimized_str = re.sub(" +", " ", extracted_str)
         else:
             optimized_str = extracted_str
 

--- a/src/invoice2data/output/to_json.py
+++ b/src/invoice2data/output/to_json.py
@@ -44,8 +44,8 @@ def write_to_file(data, path, date_format="%Y-%m-%d"):
             for k, v in line.items():
                 if k.startswith("date") or k.endswith("date"):
                     line[k] = v.strftime(date_format)
-        print(type(json))
-        print(json)
+        #print(type(json))
+        #print(json)
         json.dump(
             data,
             json_file,

--- a/src/invoice2data/output/to_xml.py
+++ b/src/invoice2data/output/to_xml.py
@@ -36,26 +36,31 @@ def write_to_file(data, path, date_format="%Y-%m-%d"):
 
     """
 
-    if path.endswith(".xml"):
+    if path.endswith('.xml'):
         filename = path
     else:
-        filename = path + ".xml"
-
-    tag_data = ET.Element("data")
+        filename = path + '.xml'
+    
     xml_file = open(filename, "w")
-    i = 0
+    tag_data = ET.Element('data')
+    data = data[0]
     for line in data:
-        i += 1
-        tag_item = ET.SubElement(tag_data, "item")
-        tag_date = ET.SubElement(tag_item, "date")
-        tag_desc = ET.SubElement(tag_item, "desc")
-        tag_currency = ET.SubElement(tag_item, "currency")
-        tag_amount = ET.SubElement(tag_item, "amount")
-        tag_item.set("id", str(i))
-        tag_date.text = line["date"].strftime(date_format)
-        tag_desc.text = line["desc"]
-        tag_currency.text = line["currency"]
-        tag_amount.text = str(line["amount"])
+        if type(data[line]) == list:
+            tag_list = ET.SubElement(tag_data, 'lines')
+            i = 1
+            for line_dict in data[line]:
+                tag_line = ET.SubElement(tag_list, 'line')
+                tag_line.set('id', str(i))
+                i = i+1
+                for line_item in line_dict:
+                    tag_item = ET.SubElement(tag_line, line_item)
+                    tag_item.text = str(line_dict[line_item])
+        elif type(data[line]) == datetime:
+            tag_item = ET.SubElement(tag_data, line)
+            tag_item.text = data[line].strftime(date_format)
+        else:
+            tag_item = ET.SubElement(tag_data, line)
+            tag_item.text = str(data[line])
 
     xml_file.write(prettify(tag_data))
     xml_file.close()


### PR DESCRIPTION
3 updates

1. The remove_whitespace removed all the whitespaces merging the words together... Updated this to keep remove all the whitespaces, except 1, this will allow the use of (\w) regex

2. Removed the print statements in to_json.py as they were coming up in the command line.

3. XML export only had few items being exported, update the to_xml.py to add in all the line in a structured format. The tags become the keys and the text as the values.. The invoice lines have <lines> and <line> tags. This is based on the list datatype. Have not tested for tables though.