### PR TITLE
Area Plugin Support 

### DIFF
--- a/src/invoice2data/extract/invoice_template.py
+++ b/src/invoice2data/extract/invoice_template.py
@@ -9,7 +9,7 @@ import dateparser
 from unidecode import unidecode
 import logging
 from collections import OrderedDict
-from .plugins import lines, tables
+from .plugins import lines, tables,area
 
 logger = logging.getLogger(__name__)
 
@@ -24,7 +24,7 @@ OPTIONS_DEFAULT = {
     "replace": [],  # example: see templates/fr/fr.free.mobile.yml
 }
 
-PLUGIN_MAPPING = {"lines": lines, "tables": tables}
+PLUGIN_MAPPING = {"lines": lines, "tables": tables, 'area':area}
 
 
 class InvoiceTemplate(OrderedDict):
@@ -130,7 +130,7 @@ class InvoiceTemplate(OrderedDict):
             return self.parse_date(value)
         assert False, "Unknown type"
 
-    def extract(self, optimized_str):
+    def extract(self, optimized_str,path):
         """
         Given a template file and a string, extract matching data fields.
         """
@@ -206,7 +206,7 @@ class InvoiceTemplate(OrderedDict):
         # Run plugins:
         for plugin_keyword, plugin_func in PLUGIN_MAPPING.items():
             if plugin_keyword in self.keys():
-                plugin_func.extract(self, optimized_str, output)
+                plugin_func.extract(self, optimized_str, path, output)
 
         # If required fields were found, return output, else log error.
         if "required_fields" not in self.keys():

--- a/src/invoice2data/extract/plugins/area.py
+++ b/src/invoice2data/extract/plugins/area.py
@@ -1,0 +1,57 @@
+"""
+Plugin to extract tables from an invoice.
+"""
+
+import logging
+import re
+import subprocess
+from distutils import spawn  # py2 compat
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_OPTIONS = {'field_separator': r'\s+', 'line_separator': r'\n'}
+
+
+def extract(self, content, path, output):
+    """Try to extract values using area from an invoice"""
+
+    for area in self['area']:
+
+        # First apply default options.
+        plugin_settings = DEFAULT_OPTIONS.copy()
+        plugin_settings.update(area)
+        area = plugin_settings
+
+        # Validate settings
+        assert 'name' in area, 'Area name  missing'
+        assert 'area' in area, 'Area area details missing'
+        assert 'r' in area["area"], 'Area R details missing'
+        assert 'x' in area["area"], 'Area X details missing'
+        assert 'y' in area["area"], 'Area y details missing'
+        assert 'W' in area["area"], 'Area W details missing'
+        assert 'H' in area["area"], 'Area H details missing'
+        r = str(area['area']["r"])
+        x = str(area['area']["x"])
+        y = str(area['area']["y"])
+        W = str(area['area']["W"])
+        H = str(area['area']["H"])
+        if spawn.find_executable("pdftotext"):  # shutil.which('pdftotext'):
+            out, err = subprocess.Popen(
+                ["pdftotext","-layout", "-enc", "UTF-8",'-r',r,'-x',x,'-y',y,'-W',W,'-H',H, path, '-'],
+                stdout=subprocess.PIPE
+
+
+            ).communicate()
+            if 'regex' in area:
+                reg_string = re.search(area["regex"], out.decode("utf-8"))
+                output[area["name"]] = reg_string.group()
+            else:
+                output[area["name"]] = out.decode("utf-8")
+        else:
+            raise EnvironmentError(
+                'pdftotext not installed. Can be downloaded from https://poppler.freedesktop.org/'
+            )
+
+
+
+            # logger.debug('ignoring *%s* because it doesn\'t match anything', line)

--- a/src/invoice2data/extract/plugins/area.py
+++ b/src/invoice2data/extract/plugins/area.py
@@ -1,5 +1,5 @@
 """
-Plugin to extract tables from an invoice.
+Plugin to extract area from an invoice.
 """
 
 import logging

--- a/src/invoice2data/extract/plugins/lines.py
+++ b/src/invoice2data/extract/plugins/lines.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_OPTIONS = {"field_separator": r"\s+", "line_separator": r"\n"}
 
 
-def extract(self, content, output):
+def extract(self, content, path, output):
     """Try to extract lines from the invoice"""
 
     # First apply default options.

--- a/src/invoice2data/extract/plugins/tables.py
+++ b/src/invoice2data/extract/plugins/tables.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_OPTIONS = {"field_separator": r"\s+", "line_separator": r"\n"}
 
 
-def extract(self, content, output):
+def extract(self, content, path, output):
     """Try to extract tables from an invoice"""
 
     for table in self["tables"]:

--- a/src/invoice2data/main.py
+++ b/src/invoice2data/main.py
@@ -90,7 +90,7 @@ def extract_data(invoicefile, templates=None, input_module=pdftotext):
         optimized_str = t.prepare_input(extracted_str)
 
         if t.matches_input(optimized_str):
-            return t.extract(optimized_str)
+            return t.extract(optimized_str,invoicefile)
 
     logger.error("No template for %s", invoicefile)
     return False


### PR DESCRIPTION
An invoice2data `area `plugin helps in extracting text on the basis of area coordinates utilizing [pdf2text area cropping option](https://prnt.sc/v1uvhl). An area plugin is customization to invoice2data to define area cropping with coordinates. Coordinates defined for the template can vary from pdf to pdf.
You just have to add a normal template containing the YAML file in which there are different plugins for fields and tables and you just have to add an area plugin and it works on every pdf.
Just write the field of multiple lines you want to extract and give the coordinates of that field that is (`x=? y=? r=? H=? W=?`)
```
x = x coordinate
y = y coordinate
H= height of the area
W= width of the area 
R= resolution of invoice
```
**Area Plugin Options:** 
Name: field name to map with extracted text
Area: takes dict as input for cropping pdf area and extract text
Regex: Optional parameter, used for further extracting text from the cropped area.
[Sample Invoice ](https://prnt.sc/v1uyl6)

Here is a sample of an invoice template including the area plugin that helps you extract multiple lines.
```
# -*- coding: utf-8 -*-
issuer: The XYZ Company
keywords:
- The XYZ Company
- US Supplier 123
fields:
	amount: TOTAL:\s+(\d+,\d+\.\d\d)
	date: Invoice Date:\s+(\d{1,2}\/\d{1,2}\/\d{4})
	delivery_date: Delivery Date:\s+(\d{1,2}\/\d{1,2}\/\d{4})
	invoice_number: INVOICE:\s+(\w{3}\d{1,8})
	sales_order : Sales Order:\s+(\w{2}\d+)
tables:
	-   start: Line\s+Product\s+Description\s+Quantity
    	end: Prices
    	body: (?P<Line>^\d{2})\s+(?P<Product>\w{2}\-\w{2}\-\w+\-\w+)\s+(?P<Description>\w+\s\w+\s\w+\-\w+)\s+(?P<Quantity>\d+)
area:
    -  name: "Address"
       area: {x: 115,y: 124,r: 300,W: 412, H: 326}
       regex: \w+
     - name: "Bill_to"
       area: {x: 930,y: 416,r: 300,W: 310, H: 294}

options:
	remove_whitespace: false
	currency: USD
	date_formats:
    	- '%d/%m/%Y'
	languages:
    	- en
decimal_separator: '.'

```
Output :
```
{'issuer': 'Innomatiq', 'amount': 51500.0, 'date': datetime.datetime(2020, 3, 12, 0, 0), 'invoice_number': 'INV0005', 'Terms': 'Due On Receipt', 'cur
rency': 'USD', 'DESCRIPTION': 'Laptops', 'RATE': '$1,500.00', 'QTY': '1', 'AMOUNT': '$1,500.00', 'Address': 'Invoice INV0005 \r\nInnomatiq\r\n\r\nSuite 2000\r\nPlano, TX\r\n75023\r\n\r\nmail@innomatiq.com', 'Bill_to': 'Dell 7\r\nRound Rock, Tx\r\n78664\r\n(800) 285-1653\r\nJoe@IBM.com', 'desc': 'Invoice from Innomatiq'}
```


