### PR TITLE
Extend fields syntax to support associative arrays & add 2 initial parsers

### DIFF
--- a/TUTORIAL.rst
+++ b/TUTORIAL.rst
@@ -53,10 +53,18 @@ Fields
 
 All the regex ``fields`` you need extracted. Required fields are
 ``amount``, ``date``, ``invoice_number``. It’s up to you, if you need
-more fields extracted. Each field has one or more regex with one regex
-capturing group. It’s not required to put add the whole regex to the
-capturing group. Often we use keywords and only capture part of the
-match (e.g. the amount).
+more fields extracted. Each field can be defined as:
+
+-  an **associative array** with ``parser`` specifying parsing method
+-  a single regex with one capturing group
+-  an array of regexes
+
+The first method is preferred. It was introduced to make templates
+syntax cleaner and more flexible. It aims to replace old methods.
+
+It’s not required to put add the whole regex to the capturing group.
+Often we use keywords and only capture part of the match (e.g. the
+amount).
 
 You will need to understand regular expressions to find the right
 values. If you didn’t need them in your life up until now (lucky you),
@@ -66,6 +74,9 @@ here <http://www.regexr.com/>`__. We use `Python’s regex
 engine <https://docs.python.org/2/library/re.html>`__. It won’t matter
 for the simple expressions we need, but sometimes there are subtle
 differences when e.g. coming from Perl.
+
+Legacy regexes
+~~~~~~~~~~~~~~
 
 For non-text fields, the name of the field is important:
 

--- a/TUTORIAL.rst
+++ b/TUTORIAL.rst
@@ -75,6 +75,20 @@ engine <https://docs.python.org/2/library/re.html>`__. It won’t matter
 for the simple expressions we need, but sometimes there are subtle
 differences when e.g. coming from Perl.
 
+Parser ``static``
+~~~~~~~~~~~~~~~~~
+
+This pseudo-parser sets field with a content of ``value`` field.
+
+Example:
+
+::
+
+    fields:
+      friendly_name:
+        parser: static
+        value: Amazon
+
 Legacy regexes
 ~~~~~~~~~~~~~~
 

--- a/TUTORIAL.rst
+++ b/TUTORIAL.rst
@@ -75,6 +75,44 @@ engine <https://docs.python.org/2/library/re.html>`__. It won’t matter
 for the simple expressions we need, but sometimes there are subtle
 differences when e.g. coming from Perl.
 
+Parser ``regex``
+~~~~~~~~~~~~~~~~
+
+It's the basic parser that allows parsing content using regexes. The
+only required property is ``regex`` that has to contain one or multiple
+(specified using array) regexes.
+
+By default ``regex`` parser removes all duplicated matches. It results a
+single value or an array (depending an amount of unique matches found).
+
+Optional properties:
+
+-  ``type`` (if present must be one of: ``int``, ``float``, ``date``) -
+   results in parsing every matched value to a specified type
+-  ``group`` (if present must be ``sum``) - results in grouping all
+   matched values using specified method
+
+Example for ``regex``:
+
+::
+
+    fields:
+      amount:
+        parser: regex
+        regex: Total:\s+(\d+\.\d+) EUR
+        type: float
+      date:
+        parser: regex
+        regex: Issued on:\s+(\d{4}-\d{2}-\d{2})
+        type: date
+      advance:
+        parser: regex
+        regex:
+          - Advance payment:\s+(\d+\.\d+)
+          - Paid in advance:\s+(\d+\.\d+)
+        type: float
+        group: sum
+
 Parser ``static``
 ~~~~~~~~~~~~~~~~~
 

--- a/TUTORIAL.rst
+++ b/TUTORIAL.rst
@@ -89,6 +89,27 @@ Example:
         parser: static
         value: Amazon
 
+Parser ``lines``
+~~~~~~~~~~~~~~~~
+
+This parser allows parsing selected invoice section as a set of lines
+sharing some pattern. Those can be e.g. invoice items (good or services)
+or VAT rates.
+
+It replaces ``lines`` plugin and should be preferred over it. It allows
+reusing in multiple ``fields``.
+
+Example for ``fields``:
+
+::
+
+    fields:
+      lines:
+        parser: lines
+        start: Item\s+Discount\s+Price$
+        end: \s+Total
+        line: (?P<description>.+)\s+(?P<discount>\d+.\d+)\s+(?P<price>\d+\d+)
+
 Legacy regexes
 ~~~~~~~~~~~~~~
 

--- a/src/invoice2data/extract/invoice_template.py
+++ b/src/invoice2data/extract/invoice_template.py
@@ -25,7 +25,7 @@ OPTIONS_DEFAULT = {
     "replace": [],  # example: see templates/fr/fr.free.mobile.yml
 }
 
-PARSERS_MAPPING = {}
+PARSERS_MAPPING = {"static": parsers.static}
 
 PLUGIN_MAPPING = {"lines": lines, "tables": tables}
 

--- a/src/invoice2data/extract/invoice_template.py
+++ b/src/invoice2data/extract/invoice_template.py
@@ -25,7 +25,7 @@ OPTIONS_DEFAULT = {
     "replace": [],  # example: see templates/fr/fr.free.mobile.yml
 }
 
-PARSERS_MAPPING = {"lines": parsers.lines, "static": parsers.static}
+PARSERS_MAPPING = {"lines": parsers.lines, "regex": parsers.regex, "static": parsers.static}
 
 PLUGIN_MAPPING = {"lines": lines, "tables": tables}
 
@@ -174,48 +174,25 @@ class InvoiceTemplate(OrderedDict):
                 logger.debug("field=%s | static value=%s", k, v)
                 output[k.replace("static_", "")] = v
             else:
+                # Legacy syntax support (backward compatibility)
                 logger.debug("field=%s | regexp=%s", k, v)
 
-                sum_field = False
+                result = None
                 if k.startswith("sum_amount") and type(v) is list:
-                    k = k[4:]  # remove 'sum_' prefix
-                    sum_field = True
-                # Fields can have multiple expressions
-                if type(v) is list:
-                    res_find = []
-                    for v_option in v:
-                        res_val = re.findall(v_option, optimized_str)
-                        if res_val:
-                            if sum_field:
-                                res_find += res_val
-                            else:
-                                res_find.extend(res_val)
+                    k = k[4:]
+                    result = parsers.regex.parse(self, {"regex": v, "type": "float", "group": "sum"}, optimized_str,
+                                                 True)
+                elif k.startswith("date") or k.endswith("date"):
+                    result = parsers.regex.parse(self, {"regex": v, "type": "date"}, optimized_str, True)
+                elif k.startswith("amount"):
+                    result = parsers.regex.parse(self, {"regex": v, "type": "float"}, optimized_str, True)
                 else:
-                    res_find = re.findall(v, optimized_str)
-                if res_find:
-                    logger.debug("res_find=%s", res_find)
-                    if k.startswith("date") or k.endswith("date"):
-                        output[k] = self.parse_date(res_find[0])
-                        if not output[k]:
-                            logger.error(
-                                "Date parsing failed on date '%s'", res_find[0]
-                            )
-                            return None
-                    elif k.startswith("amount"):
-                        if sum_field:
-                            output[k] = 0
-                            for amount_to_parse in res_find:
-                                output[k] += self.parse_number(amount_to_parse)
-                        else:
-                            output[k] = self.parse_number(res_find[0])
-                    else:
-                        res_find = list(set(res_find))
-                        if len(res_find) == 1:
-                            output[k] = res_find[0]
-                        else:
-                            output[k] = res_find
-                else:
+                    result = parsers.regex.parse(self, {"regex": v}, optimized_str, True)
+
+                if result is None:
                     logger.warning("regexp for field %s didn't match", k)
+                else:
+                    output[k] = result
 
         output["currency"] = self.options["currency"]
 

--- a/src/invoice2data/extract/invoice_template.py
+++ b/src/invoice2data/extract/invoice_template.py
@@ -25,7 +25,7 @@ OPTIONS_DEFAULT = {
     "replace": [],  # example: see templates/fr/fr.free.mobile.yml
 }
 
-PARSERS_MAPPING = {"static": parsers.static}
+PARSERS_MAPPING = {"lines": parsers.lines, "static": parsers.static}
 
 PLUGIN_MAPPING = {"lines": lines, "tables": tables}
 

--- a/src/invoice2data/extract/parsers/__init__.py
+++ b/src/invoice2data/extract/parsers/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: MIT

--- a/src/invoice2data/extract/parsers/__init__.py
+++ b/src/invoice2data/extract/parsers/__init__.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: MIT
 
 from . import lines  # noqa: F401
+from . import regex  # noqa: F401
 from . import static  # noqa: F401

--- a/src/invoice2data/extract/parsers/__init__.py
+++ b/src/invoice2data/extract/parsers/__init__.py
@@ -1,3 +1,4 @@
 # SPDX-License-Identifier: MIT
 
+from . import lines  # noqa: F401
 from . import static  # noqa: F401

--- a/src/invoice2data/extract/parsers/__init__.py
+++ b/src/invoice2data/extract/parsers/__init__.py
@@ -1,1 +1,3 @@
 # SPDX-License-Identifier: MIT
+
+from . import static  # noqa: F401

--- a/src/invoice2data/extract/parsers/__interface__.py
+++ b/src/invoice2data/extract/parsers/__interface__.py
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: MIT
+
+"""
+Interface for fields parsers.
+
+Parsers are basic modules used for extracting data. They are responsible
+for parsing invoice text using specified settings. Depending on a parser
+and settings it may be e.g.:
+1. Looking for a single value
+2. Grouping multiple occurences (e.g. summing up)
+3. Finding repeating parts (e.g. multiple rows)
+
+Each parser is a module (file) in the package `parsers` and provides at
+a minimum the `parse` function with those arguments:
+
+def parse(template, settings, content)
+
+Parser has to return a single value (e.g. number, date, string, array)
+or None in case of error. Such a value will be included in the output.
+"""

--- a/src/invoice2data/extract/parsers/lines.py
+++ b/src/invoice2data/extract/parsers/lines.py
@@ -1,0 +1,87 @@
+"""
+Parser to extract individual lines from an invoice.
+
+Initial work and maintenance by Holger Brunn @hbrunn
+"""
+
+import re
+import logging
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_OPTIONS = {"line_separator": r"\n"}
+
+
+def parse(template, _settings, content):
+    """Try to extract lines from the invoice"""
+
+    # First apply default options.
+    settings = DEFAULT_OPTIONS.copy()
+    settings.update(_settings)
+
+    # Validate settings
+    assert "start" in settings, "Lines start regex missing"
+    assert "end" in settings, "Lines end regex missing"
+    assert "line" in settings, "Line regex missing"
+
+    start = re.search(settings["start"], content)
+    end = re.search(settings["end"], content)
+    if not start or not end:
+        logger.warning("no lines found - start %s, end %s", start, end)
+        return
+    content = content[start.end() : end.start()]
+    lines = []
+    current_row = {}
+    if "first_line" not in settings and "last_line" not in settings:
+        settings["first_line"] = settings["line"]
+    for line in re.split(settings["line_separator"], content):
+        # if the line has empty lines in it , skip them
+        if not line.strip("").strip("\n") or not line:
+            continue
+        if "first_line" in settings:
+            match = re.search(settings["first_line"], line)
+            if match:
+                if "last_line" not in settings:
+                    if current_row:
+                        lines.append(current_row)
+                    current_row = {}
+                if current_row:
+                    lines.append(current_row)
+                current_row = {
+                    field: value.strip() if value else ""
+                    for field, value in match.groupdict().items()
+                }
+                continue
+        if "last_line" in settings:
+            match = re.search(settings["last_line"], line)
+            if match:
+                for field, value in match.groupdict().items():
+                    current_row[field] = "%s%s%s" % (
+                        current_row.get(field, ""),
+                        current_row.get(field, "") and "\n" or "",
+                        value.strip() if value else "",
+                    )
+                if current_row:
+                    lines.append(current_row)
+                current_row = {}
+                continue
+        match = re.search(settings["line"], line)
+        if match:
+            for field, value in match.groupdict().items():
+                current_row[field] = "%s%s%s" % (
+                    current_row.get(field, ""),
+                    current_row.get(field, "") and "\n" or "",
+                    value.strip() if value else "",
+                )
+            continue
+        logger.debug("ignoring *%s* because it doesn't match anything", line)
+    if current_row:
+        lines.append(current_row)
+
+    types = settings.get("types", [])
+    for row in lines:
+        for name in row.keys():
+            if name in types:
+                row[name] = template.coerce_type(row[name], types[name])
+
+    return lines

--- a/src/invoice2data/extract/parsers/regex.py
+++ b/src/invoice2data/extract/parsers/regex.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: MIT
+
+"""
+Parser extracting data using regexes.
+
+One or more regexes can be specified using the "regex" setting.
+By default it ignores duplicates and returns:
+- single value if there was only a single match
+- array for multiple matches
+
+For more detailed parsing "type" and "group" settings can be specified.
+"""
+
+import re
+import logging
+from collections import OrderedDict
+
+logger = logging.getLogger(__name__)
+
+
+def parse(template, settings, content, legacy=False):
+    if "regex" not in settings:
+        return None
+
+    result = []
+    if isinstance(settings["regex"], list):
+        for regex in settings["regex"]:
+            matches = re.findall(regex, content)
+            if matches:
+                result += matches
+    else:
+        result = re.findall(settings["regex"], content)
+
+    if "type" in settings:
+        for k, v in enumerate(result):
+            result[k] = template.coerce_type(v, settings["type"])
+
+    if "group" in settings:
+        if settings["group"] == "sum":
+            result = sum(result)
+        else:
+            logger.warning("Unsupported grouping method: " + settings["group"])
+            return None
+    else:
+        # Remove duplicates maintaining the order by default (it's more
+        # natural). Don't do that for legacy parsing to keep backward
+        # compatibility.
+        if legacy:
+            result = list(set(result))
+        else:
+            result = list(OrderedDict.fromkeys(result))
+
+    if isinstance(result, list) and len(result) == 1:
+        result = result[0]
+
+    return result

--- a/src/invoice2data/extract/parsers/static.py
+++ b/src/invoice2data/extract/parsers/static.py
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: MIT
+
+"""
+Pseudo-parser returning a static (predefined) value
+"""
+
+
+def parse(template, settings, content):
+    if "value" not in settings:
+        return None
+    return settings["value"]

--- a/src/invoice2data/extract/plugins/__interface__.py
+++ b/src/invoice2data/extract/plugins/__interface__.py
@@ -1,6 +1,14 @@
 """
 Interface for extraction plugins.
 
+Plugins are used for extracting more complex data and should be used
+only if they can't fit parsers design. They can't be used in the
+standard `fields` associative array.
+
+The main advantage of plugins (as the cost of clean template
+integration) is full access to the output. It allows plugins to e.g.
+set multiple output entires.
+
 Each plugin is a module (file) in package `plugins` that provides at a minimum the `extract`
 function with those arguments:
 

--- a/src/invoice2data/extract/plugins/lines.py
+++ b/src/invoice2data/extract/plugins/lines.py
@@ -1,89 +1,15 @@
 """
 Plugin to extract individual lines from an invoice.
 
-Initial work and maintenance by Holger Brunn @hbrunn
+This plugin has been replaced by the "lines" parser. All new templates
+should use the parser instead. It's provided for backward compatibility
+only.
 """
 
-import re
-import logging
-
-logger = logging.getLogger(__name__)
-
-DEFAULT_OPTIONS = {"field_separator": r"\s+", "line_separator": r"\n"}
+from .. import parsers
 
 
 def extract(self, content, output):
-    """Try to extract lines from the invoice"""
-
-    # First apply default options.
-    plugin_settings = DEFAULT_OPTIONS.copy()
-    plugin_settings.update(self["lines"])
-    self["lines"] = plugin_settings
-
-    # Validate settings
-    assert "start" in self["lines"], "Lines start regex missing"
-    assert "end" in self["lines"], "Lines end regex missing"
-    assert "line" in self["lines"], "Line regex missing"
-
-    start = re.search(self["lines"]["start"], content)
-    end = re.search(self["lines"]["end"], content)
-    if not start or not end:
-        logger.warning("no lines found - start %s, end %s", start, end)
-        return
-    content = content[start.end() : end.start()]
-    lines = []
-    current_row = {}
-    if "first_line" not in self["lines"] and "last_line" not in self["lines"]:
-        self["lines"]["first_line"] = self["lines"]["line"]
-    for line in re.split(self["lines"]["line_separator"], content):
-        # if the line has empty lines in it , skip them
-        if not line.strip("").strip("\n") or not line:
-            continue
-        if "first_line" in self["lines"]:
-            match = re.search(self["lines"]["first_line"], line)
-            if match:
-                if "last_line" not in self["lines"]:
-                    if current_row:
-                        lines.append(current_row)
-                    current_row = {}
-                if current_row:
-                    lines.append(current_row)
-                current_row = {
-                    field: value.strip() if value else ""
-                    for field, value in match.groupdict().items()
-                }
-                continue
-        if "last_line" in self["lines"]:
-            match = re.search(self["lines"]["last_line"], line)
-            if match:
-                for field, value in match.groupdict().items():
-                    current_row[field] = "%s%s%s" % (
-                        current_row.get(field, ""),
-                        current_row.get(field, "") and "\n" or "",
-                        value.strip() if value else "",
-                    )
-                if current_row:
-                    lines.append(current_row)
-                current_row = {}
-                continue
-        match = re.search(self["lines"]["line"], line)
-        if match:
-            for field, value in match.groupdict().items():
-                current_row[field] = "%s%s%s" % (
-                    current_row.get(field, ""),
-                    current_row.get(field, "") and "\n" or "",
-                    value.strip() if value else "",
-                )
-            continue
-        logger.debug("ignoring *%s* because it doesn't match anything", line)
-    if current_row:
-        lines.append(current_row)
-
-    types = self["lines"].get("types", [])
-    for row in lines:
-        for name in row.keys():
-            if name in types:
-                row[name] = self.coerce_type(row[name], types[name])
-
-    if lines:
+    lines = parsers.lines.parse(self, self["lines"], content)
+    if lines is not None:
         output["lines"] = lines


### PR DESCRIPTION
This pull request implements ideas and features described / requested in the:
- #296
- #307

This adds support for following syntax:
```
fields:
  friendly_name:
    parser: static
    value: Amazon
  rates:
    parser: lines
    start: ...
    end: ...
    line: ...
```

I took care of properly describing every commit so let me just copy & paste their messages here:
```
parsers: translate lines plugin into a parser

This allows reusing code parsing lines in multiple fields. It doesn't
break backward compatibility as the old lines plugin syntax is still
supported.

Syntax example:

fields:
  example:
    parser: lines
    start: ...
    end: ...
    line: ...
```
```
parsers: add static parser

It's a trivial pseudo-parser that matches a behaviour of fields defined
using static_foo name. It simply returns content of the "value".

Syntax example:

fields:
  example:
    parser: static
    value: Lorem ipsum
```
```
add parsers concept for fields defined as YAML associative arrays

So far fields could be defined only as a name + regex pair. All special
cases were handled in a bit hacky way - by using properly formatter
field name (e.g. "static_foo" or "sum_amount_foo").

This change allows defining field in YAML template as an associative
array (Python dictionary). It's a cleaner way, results in more scalable
design and allows specifying more per-field details if needed.

The new syntax requires specifing parser by its name. Name "parser" was
used to distinguish it from plugins. It should be also a bit more
meaningful as plugins are often considered some external code.

Syntax example:

fields:
  example:
    parser: foo
    data: bar
```