### PR TITLE
templates: pl: add Orlen parsing template

### DIFF
--- a/src/invoice2data/extract/templates/pl/pl.orlen.yml
+++ b/src/invoice2data/extract/templates/pl/pl.orlen.yml
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: MIT
+issuer: Polski Koncern Naftowy ORLEN spółka akcyjna
+keywords:
+  - Polski Koncern Naftowy ORLEN S.A.
+  - '774-00-01-454'
+fields:
+  date: Data wystawienia:\s+(\d{4}-\d{2}-\d{2})
+  invoice_number: Faktura nr:\s+([\dA-Z/]+)
+  amount: Należność ogółem:\s+(\d+,\d\d)
+  vat:
+    parser: static
+    value: 7740001454
+  sums:
+    parser: lines
+    start: Razem:.*
+    end: Należność ogółem
+    line: ^\s*w tym:\s+(?P<net>\d+,\d\d)\s+(?P<rate>\d+)\s+(?P<vat>\d+,\d\d)\s+(?P<gross>\d+,\d\d)$
+    types:
+      net: float
+      rate: int
+      vat: float
+      gross: float
+options:
+  currency: PLN
+  date_formats:
+    - '%Y-%m-%d'
+  decimal_separator: ','


### PR DESCRIPTION
Every Polish invoice contains summary of invoice lines that groups lines by their VAT rate. There is always at least 1 summary line (can be more depending an amount of unique VAT rates).

This template adds parsing for Orlen invoices and it uses the new YAML syntax for summary lines.

Example

Invoice lines:
```

┌─────────┬───────┬──────┬──────┐
│ Service │  Net  │ Rate │ VAT  │
├─────────┼───────┼──────┼──────┤
│ Foo     │ 10,00 │ 5%   │ 0,50 │
│ Bar     │ 20,00 │ 5%   │ 1,00 │
│ Qux     │ 15,00 │ 23%  │ 3,45 │
└─────────┴───────┴──────┴──────┘
```
Rate based sums:
```

┌───────┬──────┬──────┬───────┐
│  Net  │ Rate │ VAT  │ Gross │
├───────┼──────┼──────┼───────┤
│ 30,00 │ 5%   │ 1,50 │ 31,50 │
│ 15,00 │ 23%  │ 3,45 │ 18,45 │
└───────┴──────┴──────┴───────┘
```
JSON output:
```
'vat_rates_OR_summary_OR_sums_OR_other': [
	{ 'net': 30.0, 'rate': 5, 'vat': 1.5, 'gross': 31.5 }
	{ 'net': 15.0, 'rate': 23, 'vat': 3.45, 'gross': 18.45 }
]
```
What do you think is the best `fields` entry name for such a summary? I'd like to reuse it for more templates. My ideas:

1. `vat_lines`
2. `vat_rates`
3. `summary`
4. `sums`