### PR TITLE
Update example template

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -297,7 +297,7 @@ options and their defaults are:
       - FR25499247138
       - Facture
     required_fields:
-      - static_vat
+      - vat
       - invoice_number
     options:
       currency: EUR


### PR DESCRIPTION
As the parser formats and then removes "static_" prefix and only returns "vat" part in the result object this example will never succeed as "static_vat" never exists in the result.