### PR TITLE
Added area support for fields

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -58,7 +58,12 @@ All the regex `fields` you need extracted. Required fields are `amount`,
 `date`, `invoice_number`. It's up to you, if you need more fields
 extracted. Each field can be defined as:
 
-- an **associative array** with `parser` specifying parsing method
+- an **associative array** with 
+`parser` (required) specifying parsing method and 
+`area` (optional) specifying the region of the pdf to search. 
+This takes the following arguments: `f` (first page), `l` (last page), `x` (top-left x-coord), `y` (top-left y-coord), 
+`r` (resolution), `W` (width in pixels) and `H` (height in pixels). When setting your region, ensure the resolution in your 
+image editor matches the resolution specified for `r` in this option. If not, it will not line up properly.
 - a single regex with one capturing group
 - an array of regexes
 
@@ -103,6 +108,7 @@ Example for `regex`:
         type: float
       date:
         parser: regex
+        area: {f: 1, l: 1, x: 110, y: 50, r: 300, W: 100, H: 200}
         regex: Issued on:\s+(\d{4}-\d{2}-\d{2})
         type: date
       advance:

--- a/src/invoice2data/extract/invoice_template.py
+++ b/src/invoice2data/extract/invoice_template.py
@@ -214,7 +214,7 @@ class InvoiceTemplate(OrderedDict):
                     # e.g. "parser: regex" requires "regex: [pattern]"
                     if v["parser"] in PARSERS_MAPPING:
                         parser = PARSERS_MAPPING[v["parser"]]
-                        value = parser.parse(self, v, optimized_str)
+                        value = parser.parse(self, v, optimized_str_for_parser)
                         if value is not None:
                             output[k] = value
                         else:

--- a/src/invoice2data/extract/invoice_template.py
+++ b/src/invoice2data/extract/invoice_template.py
@@ -11,6 +11,9 @@ import logging
 from collections import OrderedDict
 from . import parsers
 from .plugins import lines, tables
+# Area extraction is currently only added for pdftotext
+from ..input import pdftotext
+from typing import Optional
 
 logger = logging.getLogger(__name__)
 
@@ -71,7 +74,7 @@ class InvoiceTemplate(OrderedDict):
         Input raw string and do transformations, as set in template file.
         """
 
-        # Remove withspace
+        # Remove whitespace
         if self.options["remove_whitespace"]:
             optimized_str = re.sub(" +", "", extracted_str)
         else:
@@ -81,11 +84,11 @@ class InvoiceTemplate(OrderedDict):
         if self.options["remove_accents"]:
             optimized_str = unidecode(optimized_str)
 
-        # convert to lower case
+        # Convert to lower case
         if self.options["lowercase"]:
             optimized_str = optimized_str.lower()
 
-        # specific replace
+        # Specific replace
         for replace in self.options["replace"]:
             assert len(replace) == 2, "A replace should be a list of 2 items"
             optimized_str = optimized_str.replace(replace[0], replace[1])
@@ -151,11 +154,21 @@ class InvoiceTemplate(OrderedDict):
             return self.parse_date(value)
         assert False, "Unknown type"
 
-    def extract(self, optimized_str):
+    def extract(self, optimized_str: str, invoice_file: str, input_module: str) -> Optional[dict]:
         """
         Given a template file and a string, extract matching data fields.
-        """
 
+        Args:
+        optimized_str: String of the full text from pdf with template options applied.
+        invoice_file: String of the path to the file being processed.
+            - This is used when processing areas
+        input_module: String of the input module to be used for pdf conversion
+            - This is used when processing areas
+
+        Returns:
+        Dictionary of results if all required fields were found.
+        None if required fields are missing.
+        """
         logger.debug("START optimized_str ========================")
         logger.debug(optimized_str)
         logger.debug("END optimized_str ==========================")
@@ -175,8 +188,30 @@ class InvoiceTemplate(OrderedDict):
         output["issuer"] = self["issuer"]
 
         for k, v in self["fields"].items():
+            # k is the key of the field
+            # v is the value
             if isinstance(v, dict):
+                # Options were supplied to this field
+                if "area" in v:
+                    # area is optional and re-extracts the text being searched
+                    # This obviously has a performance impact, so use wisely
+                    # Verify that the input_module is set to pdftotext ... this is the only one included right now
+                    assert input_module == pdftotext, 'Area is currently only supported for pdftotext.'
+                    logger.debug(f"Area was specified with parameters {v['area']}")
+                    # Extract the text for the specified area
+                    # Do NOT overwrite optimized_str. We're inside a loop and it will affect all other fields!
+                    optimized_str_area = input_module.to_text(invoice_file, v['area']).decode("utf-8")
+                    # Log the text
+                    logger.debug("START pdftotext area result ===========================")
+                    logger.debug(optimized_str_area)
+                    logger.debug("END pdftotext area result =============================")
+                    optimized_str_for_parser = optimized_str_area
+                else:
+                    # No area specified
+                    optimized_str_for_parser = optimized_str
                 if "parser" in v:
+                    # parser is required and may require additional options
+                    # e.g. "parser: regex" requires "regex: [pattern]"
                     if v["parser"] in PARSERS_MAPPING:
                         parser = PARSERS_MAPPING[v["parser"]]
                         value = parser.parse(self, v, optimized_str)

--- a/src/invoice2data/input/pdftotext.py
+++ b/src/invoice2data/input/pdftotext.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-def to_text(path: str, area_details: dict=None):
+def to_text(path: str, area_details: dict = None):
     """Wrapper around Poppler pdftotext.
 
     Parameters
@@ -39,15 +39,15 @@ def to_text(path: str, area_details: dict=None):
                 area_details[key] = str(area_details[key])
             # Extract the data for the specified region
             out, err = subprocess.Popen(
-                ["pdftotext","-layout", "-enc", "UTF-8", 
-                '-f',area_details['f'], 
-                '-l',area_details['l'], 
-                '-r',area_details['r'], 
-                '-x',area_details['x'], 
-                '-y',area_details['y'], 
-                '-W',area_details['W'], 
-                '-H',area_details['H'], 
-                path, '-'],
+                ["pdftotext", "-layout", "-enc", "UTF-8",
+                    '-f', area_details['f'],
+                    '-l', area_details['l'],
+                    '-r', area_details['r'],
+                    '-x', area_details['x'],
+                    '-y', area_details['y'],
+                    '-W', area_details['W'],
+                    '-H', area_details['H'],
+                    path, '-'],
                 stdout=subprocess.PIPE
             ).communicate()
         else:

--- a/src/invoice2data/input/pdftotext.py
+++ b/src/invoice2data/input/pdftotext.py
@@ -1,11 +1,14 @@
 # -*- coding: utf-8 -*-
-def to_text(path):
+def to_text(path: str, area_details: dict=None):
     """Wrapper around Poppler pdftotext.
 
     Parameters
     ----------
     path : str
         path of electronic invoice in PDF
+    area_details : dictionary
+        of the format {x: int, y: int, r: int, W: int, H: int}
+        used when extracting an area of the pdf rather than the whole document
 
     Returns
     -------
@@ -21,9 +24,38 @@ def to_text(path):
     from distutils import spawn  # py2 compat
 
     if spawn.find_executable("pdftotext"):  # shutil.which('pdftotext'):
-        out, err = subprocess.Popen(
-            ["pdftotext", "-layout", "-enc", "UTF-8", path, "-"], stdout=subprocess.PIPE
-        ).communicate()
+        if area_details is not None:
+            # An area was specified
+            # Validate the required keys were provided
+            assert 'f' in area_details, 'Area r details missing'
+            assert 'l' in area_details, 'Area r details missing'
+            assert 'r' in area_details, 'Area r details missing'
+            assert 'x' in area_details, 'Area x details missing'
+            assert 'y' in area_details, 'Area y details missing'
+            assert 'W' in area_details, 'Area W details missing'
+            assert 'H' in area_details, 'Area H details missing'
+            # Convert all of the values to strings
+            for key in area_details.keys():
+                area_details[key] = str(area_details[key])
+            # Extract the data for the specified region
+            out, err = subprocess.Popen(
+                ["pdftotext","-layout", "-enc", "UTF-8", 
+                '-f',area_details['f'], 
+                '-l',area_details['l'], 
+                '-r',area_details['r'], 
+                '-x',area_details['x'], 
+                '-y',area_details['y'], 
+                '-W',area_details['W'], 
+                '-H',area_details['H'], 
+                path, '-'],
+                stdout=subprocess.PIPE
+            ).communicate()
+        else:
+            # No area was specified, so extract the entire pdf
+            out, err = subprocess.Popen(
+                ["pdftotext", "-layout", "-enc", "UTF-8", path, "-"],
+                stdout=subprocess.PIPE
+            ).communicate()
         return out
     else:
         raise EnvironmentError(

--- a/src/invoice2data/main.py
+++ b/src/invoice2data/main.py
@@ -90,7 +90,9 @@ def extract_data(invoicefile, templates=None, input_module=pdftotext):
         optimized_str = t.prepare_input(extracted_str)
 
         if t.matches_input(optimized_str):
-            return t.extract(optimized_str)
+            # Call extract with entire text and the invoicefile path
+            # The path is used if an area is called as a field option
+            return t.extract(optimized_str, invoicefile, input_module)
 
     logger.error("No template for %s", invoicefile)
     return False


### PR DESCRIPTION
Fields specifying a parser now also accept an "area" argument. This allows one to specify the page(s) and coordinates of the area to be extracted and then applies the specified parser to the results as normal :)
Currently this only works for pdftotext but could be expanded to other converters fairly easily.
Incorporated changes into all existing functions where possible to allow for ease of future maintainability.
Tutorial was updated to show new option and its syntax.

Credit for the idea and base code goes to @kavinsharma in issue #305 