### PR TITLE
Modified to_csv documentation to clarify input data type

### DIFF
--- a/src/invoice2data/output/to_csv.py
+++ b/src/invoice2data/output/to_csv.py
@@ -1,7 +1,6 @@
 import csv
 import sys
 
-
 def write_to_file(data, path, date_format="%Y-%m-%d"):
     """Export extracted fields to csv
 
@@ -40,17 +39,29 @@ def write_to_file(data, path, date_format="%Y-%m-%d"):
     with openfile as csv_file:
         writer = csv.writer(csv_file, delimiter=",")
 
-        for line in data:
-            first_row = []
-            for k, v in line.items():
-                first_row.append(k)
+        # Write header to csv
+        writer.writerow(data.keys())
 
-        writer.writerow(first_row)
-        for line in data:
-            csv_items = []
-            for k, v in line.items():
-                # first_row.append(k)
-                if k.startswith("date") or k.endswith("date"):
-                    v = v.strftime(date_format)
-                csv_items.append(v)
-            writer.writerow(csv_items)
+        # Loop through data and see which had lists of results (e.g. from lines parser)
+        csv_items = []
+        for key in data.keys():
+            value = data[key]
+            if isinstance(value, list):
+                # List of results, process each in turn
+                result_list = []
+                for item in value:
+                    if isinstance(item, dict):
+                        # The item in the list is a dictionary, so parse each key-value pair for datetime formatting
+                        for sub_key in item.keys():
+                            sub_value = item[sub_key]
+                            if sub_key.startswith("date") or sub_key.endswith("date"):
+                                # Key appears to indicate a date, so parse it as such
+                                sub_value = sub_value.strftime(date_format)
+                    result_list.append(item)
+                csv_items.append(result_list)
+            else:
+                # Single value, so parse as date if necessary
+                if key.startswith("date") or key.endswith("date"):
+                    value = value.strftime(date_format)
+                csv_items.append(value)
+        writer.writerow(csv_items)

--- a/src/invoice2data/output/to_csv.py
+++ b/src/invoice2data/output/to_csv.py
@@ -2,17 +2,18 @@ import csv
 import sys
 
 
-def write_to_file(data, path, date_format="%Y-%m-%d"):
+def write_to_file(data: list, path: str, date_format="%Y-%m-%d") -> None:
     """Export extracted fields to csv
 
     Appends .csv to path if missing and generates csv file in specified directory, if not then in root
 
     Parameters
     ----------
-    data : dict
-        Dictionary of extracted fields
+    data : list
+        A list of dictionaries of extracted fields.
+        If only a single file was processed, it must be passed as a single-element list.
     path : str
-        directory to save generated csv file
+        csv file to save output csv to
     date_format : str
         Date format used in generated file
 
@@ -40,29 +41,17 @@ def write_to_file(data, path, date_format="%Y-%m-%d"):
     with openfile as csv_file:
         writer = csv.writer(csv_file, delimiter=",")
 
-        # Write header to csv
-        writer.writerow(data.keys())
+        for line in data:
+            first_row = []
+            for k, v in line.items():
+                first_row.append(k)
 
-        # Loop through data and see which had lists of results (e.g. from lines parser)
-        csv_items = []
-        for key in data.keys():
-            value = data[key]
-            if isinstance(value, list):
-                # List of results, process each in turn
-                result_list = []
-                for item in value:
-                    if isinstance(item, dict):
-                        # The item in the list is a dictionary, so parse each key-value pair for datetime formatting
-                        for sub_key in item.keys():
-                            sub_value = item[sub_key]
-                            if sub_key.startswith("date") or sub_key.endswith("date"):
-                                # Key appears to indicate a date, so parse it as such
-                                sub_value = sub_value.strftime(date_format)
-                    result_list.append(item)
-                csv_items.append(result_list)
-            else:
-                # Single value, so parse as date if necessary
-                if key.startswith("date") or key.endswith("date"):
-                    value = value.strftime(date_format)
-                csv_items.append(value)
-        writer.writerow(csv_items)
+        writer.writerow(first_row)
+        for line in data:
+            csv_items = []
+            for k, v in line.items():
+                # first_row.append(k)
+                if k.startswith("date") or k.endswith("date"):
+                    v = v.strftime(date_format)
+                csv_items.append(v)
+            writer.writerow(csv_items)

--- a/src/invoice2data/output/to_csv.py
+++ b/src/invoice2data/output/to_csv.py
@@ -1,6 +1,7 @@
 import csv
 import sys
 
+
 def write_to_file(data, path, date_format="%Y-%m-%d"):
     """Export extracted fields to csv
 


### PR DESCRIPTION
CORRECTION: It is simply a documentation issue. The original doc indicates a dictionary being passed for the data. It is, in fact, a list of dictionaries that is required.

I was unable to get the previous to_csv.py file to work. The data I was sending to it consisted of single fields and lines. It was trying to find keys in all values, regardless of whether they were dictionaries or not.

It appears that any lines-type regex will return a list of dictionaries, so I modified the code to now check if the field is a list of dictionaries first. Only then does it start looking for keys and values in each element.

All values where the name starts or ends with "date" is still attempted to be parsed as a date format whether it is on it's own or a key inside a dictionary.

Let me know what you think :)