### PR TITLE
Replace changed to regex sub and added type hinting

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -287,7 +287,9 @@ options and their defaults are:
 - `languages` (default = \[\]): Also passed to `dateparser` to parse
   names of months.
 - `replace` (default = `[]`): Additional search and replace before
-  matching. Not needed usually.
+  matching. Each replace entry must be a list of two elements.
+  The first is the regex pattern to be replaced, the second the string
+  to replace any matches with. Replacing is not typically needed.
 - `required_fields`: By default the template should have regex for
   date, amount, invoice\_number and issuer. If you wish to extract
   different fields, you can supply a list here. The extraction will
@@ -317,6 +319,7 @@ options and their defaults are:
       decimal_separator: '.'
       replace:
         - ['e´ ', 'é']
+        - ['\s{5,}', ' ']
 
 
 ## Steps to add new template

--- a/src/invoice2data/extract/invoice_template.py
+++ b/src/invoice2data/extract/invoice_template.py
@@ -66,7 +66,7 @@ class InvoiceTemplate(OrderedDict):
         if "issuer" not in self.keys():
             self["issuer"] = self["keywords"][0]
 
-    def prepare_input(self, extracted_str):
+    def prepare_input(self, extracted_str: str) -> str:
         """
         Input raw string and do transformations, as set in template file.
         """
@@ -88,7 +88,7 @@ class InvoiceTemplate(OrderedDict):
         # specific replace
         for replace in self.options["replace"]:
             assert len(replace) == 2, "A replace should be a list of 2 items"
-            optimized_str = optimized_str.replace(replace[0], replace[1])
+            optimized_str = re.sub(replace[0], replace[1], optimized_str)
 
         return optimized_str
 

--- a/src/invoice2data/extract/invoice_template.py
+++ b/src/invoice2data/extract/invoice_template.py
@@ -87,7 +87,7 @@ class InvoiceTemplate(OrderedDict):
 
         # specific replace
         for replace in self.options["replace"]:
-            assert len(replace) == 2, "A replace should be a list of 2 items"
+            assert len(replace) == 2, "A replace should be a list of exactly 2 elements."
             optimized_str = re.sub(replace[0], replace[1], optimized_str)
 
         return optimized_str

--- a/src/invoice2data/extract/invoice_template.py
+++ b/src/invoice2data/extract/invoice_template.py
@@ -124,7 +124,7 @@ class InvoiceTemplate(OrderedDict):
         # replace decimal separator by a |
         amount_pipe = value.replace(self.options["decimal_separator"], "|")
         # remove all possible thousands separators
-        amount_pipe_no_thousand_sep = re.sub(r"[.,\s]", "", amount_pipe)
+        amount_pipe_no_thousand_sep = re.sub(r"[.,'\s]", "", amount_pipe)
         # put dot as decimal sep
         return float(amount_pipe_no_thousand_sep.replace("|", "."))
 


### PR DESCRIPTION
Switched the replace functionality from .replace to re.sub. This should maintain backwards compatibility while allowing for more complex substitutions with regex patterns such as requested in issue #302.
Also added type hinting to the function definition.