### PR TITLE
Regex: print warning when trying to use multiple capturing groups

### DIFF
--- a/src/invoice2data/extract/parsers/regex.py
+++ b/src/invoice2data/extract/parsers/regex.py
@@ -22,14 +22,20 @@ def parse(template, settings, content, legacy=False):
     if "regex" not in settings:
         return None
 
-    result = []
     if isinstance(settings["regex"], list):
-        for regex in settings["regex"]:
-            matches = re.findall(regex, content)
-            if matches:
-                result += matches
+        regexes = settings["regex"]
     else:
-        result = re.findall(settings["regex"], content)
+        regexes = [settings["regex"]]
+
+    result = []
+    for regex in regexes:
+        matches = re.findall(regex, content)
+        if matches:
+            for match in matches:
+                if isinstance(match, tuple):
+                    logger.warning("Regex can't contain multiple capturing groups (\"" + regex + "\")")
+                    return None
+            result += matches
 
     if "type" in settings:
         for k, v in enumerate(result):


### PR DESCRIPTION
It seems users have problems debugging incorrect templates with (wrong) regexes containing multiple matching groups. Example:
https://github.com/invoice-x/invoice2data/issues/347
https://github.com/invoice-x/invoice2data/issues/340

It has been also suggested that debugging template problems should be simpler in general:
https://github.com/invoice-x/invoice2data/issues/339

This change avoids exception and makes it clear what has caused a problem. Example:
```
WARNING:invoice2data.extract.parsers.regex:Regex can't contain multiple capturing groups ("Invoice Date:\s+(\d{1,2})-(\d{1,2})-(\d{2,4})")
```
```
Specifying multiple capturing groups in regex pattern in not supported.

With type parsing that could result in a TypeError exception:

File "/home/foo/invoice2data/src/invoice2data/extract/invoice_template.py", line 136, in parse_date
  languages=self.options["languages"],
File "/usr/lib/python3.6/site-packages/dateparser/conf.py", line 84, in wrapper
  return f(*args, **kwargs)
File "/usr/lib/python3.6/site-packages/dateparser/__init__.py", line 53, in parse
  data = parser.get_date_data(date_string, date_formats)
File "/usr/lib/python3.6/site-packages/dateparser/date.py", line 405, in get_date_data
  raise TypeError('Input type must be str or unicode')

Check re.findall returned array for any tuples. It's what gets returned
when using more than one capturing group.

This change prevents exception and provides a useful feedback by
specifying the problem and printing incorrect regex.

Signed-off-by: Rafał Miłecki <rafal@milecki.pl>
```