### PR TITLE
Drop debugging messages from JSON output support

### DIFF
--- a/src/invoice2data/output/to_json.py
+++ b/src/invoice2data/output/to_json.py
@@ -44,8 +44,6 @@ def write_to_file(data, path, date_format="%Y-%m-%d"):
             for k, v in line.items():
                 if k.startswith("date") or k.endswith("date"):
                     line[k] = v.strftime(date_format)
-        print(type(json))
-        print(json)
         json.dump(
             data,
             json_file,


### PR DESCRIPTION
```
This stops printing rather useless messages that seem like some
debugging leftovers:
<class 'module'>
<module 'json' from '/usr/lib64/python3.9/json/__init__.py'>

Signed-off-by: Rafał Miłecki <rafal@milecki.pl>
```