### PR TITLE
Catch yaml.parser.ParserError exception

### DIFF
--- a/src/invoice2data/extract/loader.py
+++ b/src/invoice2data/extract/loader.py
@@ -13,6 +13,8 @@ from .invoice_template import InvoiceTemplate
 import codecs
 import chardet
 
+logger = logging.getLogger(__name__)
+
 logging.getLogger("chardet").setLevel(logging.WARNING)
 
 
@@ -89,7 +91,11 @@ def read_templates(folder=None):
                 with codecs.open(
                     os.path.join(path, name), encoding=encoding
                 ) as template_file:
-                    tpl = ordered_load(template_file.read())
+                    try:
+                        tpl = ordered_load(template_file.read())
+                    except yaml.parser.ParserError as error:
+                        logger.warning("Failed to load %s template:\n%s", name, error)
+                        continue
                 tpl["template_name"] = name
 
                 # Test if all required fields are in template:


### PR DESCRIPTION
```
1. Avoid a long (and hard to understand?) traceback
2. Print template name that couldn't be parsed
3. Print exception error message

This should help users to develop their templates. Without this change
it was hard to understand which template has caused the exception.

Signed-off-by: Rafał Miłecki <rafal@milecki.pl>
```
This change tries to address some of problems pointed out in the https://github.com/invoice-x/invoice2data/issues/339