### PR TITLE
Be more verbose about loaded templates

### DIFF
--- a/src/invoice2data/extract/loader.py
+++ b/src/invoice2data/extract/loader.py
@@ -113,4 +113,7 @@ def read_templates(folder=None):
                     tpl["exclude_keywords"] = [tpl["exclude_keywords"]]
 
                 output.append(InvoiceTemplate(tpl))
+
+    logger.info("Loaded %d templates from %s", len(output), folder)
+
     return output

--- a/src/invoice2data/main.py
+++ b/src/invoice2data/main.py
@@ -85,11 +85,11 @@ def extract_data(invoicefile, templates=None, input_module=pdftotext):
     logger.debug(extracted_str)
     logger.debug("END pdftotext result =============================")
 
-    logger.debug("Testing {} template files".format(len(templates)))
     for t in templates:
         optimized_str = t.prepare_input(extracted_str)
 
         if t.matches_input(optimized_str):
+            logger.info("Using %s template", t["template_name"])
             return t.extract(optimized_str)
 
     logger.error("No template for %s", invoicefile)


### PR DESCRIPTION
```
People seem to be often confused by invoice2data CLI behaviour. When
something doesn't work the default output doesn't seem to be enough to
understand what's happening.

Try to improve that situation be printing info about templates that were
loaded and the used one. Use info level messages for that basic stuff so
it's clear what is happening even without the --debug switch.

Signed-off-by: Rafał Miłecki <rafal@milecki.pl>
```