### PR TITLE
Simplify logging output for non-debug run

### DIFF
--- a/src/invoice2data/main.py
+++ b/src/invoice2data/main.py
@@ -192,7 +192,7 @@ def main(args=None):
     if args.debug:
         logging.basicConfig(level=logging.DEBUG)
     else:
-        logging.basicConfig(level=logging.INFO)
+        logging.basicConfig(level=logging.INFO, format="%(message)s")
 
     input_module = input_mapping[args.input_reader]
     output_module = output_mapping[args.output_format]


### PR DESCRIPTION
```
Logged messages should be simple & easy to read when not running in a
debug mode. People running it for non-development purposes don't need to
know what internal classes were used.

Use the simplest logging format unless --debug is used.
```