### PR TITLE
Improve "regex" and "static" parsers logging

### DIFF
--- a/src/invoice2data/extract/invoice_template.py
+++ b/src/invoice2data/extract/invoice_template.py
@@ -179,7 +179,7 @@ class InvoiceTemplate(OrderedDict):
                 if "parser" in v:
                     if v["parser"] in PARSERS_MAPPING:
                         parser = PARSERS_MAPPING[v["parser"]]
-                        value = parser.parse(self, v, optimized_str)
+                        value = parser.parse(self, k, v, optimized_str)
                         if value is not None:
                             output[k] = value
                         else:
@@ -193,19 +193,17 @@ class InvoiceTemplate(OrderedDict):
                 output[k.replace("static_", "")] = v
             else:
                 # Legacy syntax support (backward compatibility)
-                logger.debug("field=%s | regexp=%s", k, v)
-
                 result = None
                 if k.startswith("sum_amount") and type(v) is list:
                     k = k[4:]
-                    result = parsers.regex.parse(self, {"regex": v, "type": "float", "group": "sum"}, optimized_str,
+                    result = parsers.regex.parse(self, k, {"regex": v, "type": "float", "group": "sum"}, optimized_str,
                                                  True)
                 elif k.startswith("date") or k.endswith("date"):
-                    result = parsers.regex.parse(self, {"regex": v, "type": "date"}, optimized_str, True)
+                    result = parsers.regex.parse(self, k, {"regex": v, "type": "date"}, optimized_str, True)
                 elif k.startswith("amount"):
-                    result = parsers.regex.parse(self, {"regex": v, "type": "float"}, optimized_str, True)
+                    result = parsers.regex.parse(self, k, {"regex": v, "type": "float"}, optimized_str, True)
                 else:
-                    result = parsers.regex.parse(self, {"regex": v}, optimized_str, True)
+                    result = parsers.regex.parse(self, k, {"regex": v}, optimized_str, True)
 
                 if result is None:
                     logger.warning("regexp for field %s didn't match", k)

--- a/src/invoice2data/extract/parsers/__interface__.py
+++ b/src/invoice2data/extract/parsers/__interface__.py
@@ -13,7 +13,7 @@ and settings it may be e.g.:
 Each parser is a module (file) in the package `parsers` and provides at
 a minimum the `parse` function with those arguments:
 
-def parse(template, settings, content)
+def parse(template, field, settings, content)
 
 Parser has to return a single value (e.g. number, date, string, array)
 or None in case of error. Such a value will be included in the output.

--- a/src/invoice2data/extract/parsers/lines.py
+++ b/src/invoice2data/extract/parsers/lines.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_OPTIONS = {"line_separator": r"\n"}
 
 
-def parse(template, _settings, content):
+def parse(template, field, _settings, content):
     """Try to extract lines from the invoice"""
 
     # First apply default options.

--- a/src/invoice2data/extract/parsers/regex.py
+++ b/src/invoice2data/extract/parsers/regex.py
@@ -18,8 +18,9 @@ from collections import OrderedDict
 logger = logging.getLogger(__name__)
 
 
-def parse(template, settings, content, legacy=False):
+def parse(template, field, settings, content, legacy=False):
     if "regex" not in settings:
+        logger.warning("Field \"%s\" doesn't have regex specified", field)
         return None
 
     if isinstance(settings["regex"], list):
@@ -30,6 +31,7 @@ def parse(template, settings, content, legacy=False):
     result = []
     for regex in regexes:
         matches = re.findall(regex, content)
+        logger.debug("field=%s | regex=%s | matches=%s", field, settings["regex"], matches)
         if matches:
             for match in matches:
                 if isinstance(match, tuple):

--- a/src/invoice2data/extract/parsers/static.py
+++ b/src/invoice2data/extract/parsers/static.py
@@ -4,8 +4,16 @@
 Pseudo-parser returning a static (predefined) value
 """
 
+import logging
 
-def parse(template, settings, content):
+logger = logging.getLogger(__name__)
+
+
+def parse(template, field, settings, content):
     if "value" not in settings:
+        logger.warning("Field \"%s\" doesn't have static value specified", field)
         return None
+
+    logger.debug("field=%s | value=%s", field, settings["value"])
+
     return settings["value"]

--- a/src/invoice2data/extract/plugins/lines.py
+++ b/src/invoice2data/extract/plugins/lines.py
@@ -10,6 +10,6 @@ from .. import parsers
 
 
 def extract(self, content, output):
-    lines = parsers.lines.parse(self, self["lines"], content)
+    lines = parsers.lines.parse(self, "lines", self["lines"], content)
     if lines is not None:
         output["lines"] = lines


### PR DESCRIPTION
```
Log a warning when parsing fails. Log a debugging message on success.
This should help developing templates.

Signed-off-by: Rafał Miłecki <rafal@milecki.pl>
```