### PR TITLE
test_cli Fix Assertion error due to path mismatch

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -126,7 +126,7 @@ class TestCLI(unittest.TestCase):
         main(args)
         i = 0
         for path, subdirs, files in os.walk(
-            pkg_resources.resource_filename(__name__, 'copy_test/pdf')
+            pkg_resources.resource_filename(__name__, directory)
         ):
             for file in files:
                 if file.endswith(".pdf"):


### PR DESCRIPTION
running test_cli locally results in an assertion error, because it is testing against the wrong folder.

steps to reproduce:
1. go to by `$ cd invoice2data/tests`
2. `$ python test_cli.py`

results in

```
======================================================================
FAIL: test_copy (__main__.TestCLI)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_cli.py", line 136, in test_copy
    self.assertEqual(i, len(get_sample_files('.json')))
AssertionError: 0 != 6

----------------------------------------------------------------------
```
This fix let it test against the created folder. By using the same variable.