### PR TITLE
Fix test_cli ImportError by using absolute import path

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,7 +15,7 @@ import pkg_resources
 from invoice2data.main import create_parser, main
 from invoice2data.extract.loader import read_templates
 
-from .common import get_sample_files
+from common import get_sample_files
 
 
 class TestCLI(unittest.TestCase):


### PR DESCRIPTION
```
This fixes all three:

> python3.9 tests/test_cli.py
Traceback (most recent call last):
  File "/home/rmilecki/projects/invoice2data/tests/test_cli.py", line 18, in <module>
    from .common import get_sample_files
ImportError: attempted relative import with no known parent package

--------------------

> ( cd tests; python3.9 test_cli.py )
Traceback (most recent call last):
  File "/home/rmilecki/projects/invoice2data/tests/test_cli.py", line 18, in <module>
    from .common import get_sample_files
ImportError: attempted relative import with no known parent package

--------------------

( cd tests; python3.9 -m unittest test_cli.py )
E
======================================================================
ERROR: test_cli (unittest.loader._FailedTest)
----------------------------------------------------------------------
ImportError: Failed to import test module: test_cli
Traceback (most recent call last):
  File "/usr/lib64/python3.9/unittest/loader.py", line 154, in loadTestsFromName
    module = __import__(module_name)
  File "/home/rmilecki/projects/invoice2data/tests/test_cli.py", line 18, in <module>
    from .common import get_sample_files
ImportError: attempted relative import with no known parent package

Signed-off-by: Rafał Miłecki <rafal@milecki.pl>
```