### PR TITLE
[FIX] Unittests: disable sort_keys in JSON output

### DIFF
--- a/src/invoice2data/output/to_json.py
+++ b/src/invoice2data/output/to_json.py
@@ -48,7 +48,7 @@ def write_to_file(data, path, date_format="%Y-%m-%d"):
             data,
             json_file,
             indent=4,
-            sort_keys=True,
+            sort_keys=False,
             default=myconverter,
             ensure_ascii=False,
         )


### PR DESCRIPTION
As discussed in #383

Unittests are failling because the output is in the wrong order.
From an usability pov. We want to output keys just as they were parsed from the invoice.
Eg in lines section:
Section_header
Productline 1
Productline 2

instead of (alphabetical order)
Productline 1
Productline 2
Section_header
