### PR TITLE
shift ci tests from python 3.6-3.9 to 3.8-3.10 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.10]
         os: [ubuntu-latest]
 
     steps:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,15 @@
+# -*- coding: utf-8 -*-
+# Run: python -m unittest tests.test_cli
+
+# Or: python -m unittest discover
+
+# 1. You define your own class derived from unittest.TestCase.
+# 2. Then you fill it with functions that start with 'test_'
+# 3. You run the tests by placing unittest.main() in your file,
+#    usually at the bottom.
+
+# https://docs.python.org/3.10/library/unittest.html#test-cases
+
 import datetime
 import os
 import json


### PR DESCRIPTION
Python 3.6 is deprecated.
3.10 installations are becoming more common.

Version shift the CI tests to keep track of supported python versions