### PR TITLE
support more formatting with --filename-format option

### DIFF
--- a/src/invoice2data/main.py
+++ b/src/invoice2data/main.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 
 import argparse
+import copy
+import datetime
 import shutil
 import os
 from os.path import join
@@ -222,19 +224,19 @@ def main(args=None):
         if res:
             logger.info(res)
             output.append(res)
+
+            kwargs = copy.deepcopy(res)
+            for key, value in kwargs.items():
+                if type(value) is list and len(value) >= 1:
+                    kwargs[key] = value[0]
+            for key, value in kwargs.items():
+                if type(value) is datetime.datetime:
+                    kwargs[key] = value.strftime('%Y-%m-%d')
             if args.copy:
-                filename = args.filename.format(
-                    date=res["date"].strftime("%Y-%m-%d"),
-                    invoice_number=res["invoice_number"],
-                    desc=res["desc"],
-                )
+                filename = args.filename.format(**kwargs)
                 shutil.copyfile(f.name, join(args.copy, filename))
             if args.move:
-                filename = args.filename.format(
-                    date=res["date"].strftime("%Y-%m-%d"),
-                    invoice_number=res["invoice_number"],
-                    desc=res["desc"],
-                )
+                filename = args.filename.format(**kwargs)
                 shutil.move(f.name, join(args.move, filename))
         f.close()
 


### PR DESCRIPTION
```
Before this change --filename-format accepted string with up to three
variables only ("date", "invoice_number" and "desc"). It also couldn't
deal with "date" being a list of dates.

This change allows using any parsed field. It supports date in any
field. It also deals with list of dates by picking the first one.

Example usage:
--filename-format "{date} {issuer} {invoice_number} {currency}.pdf"
```