### PR TITLE
tests: print file for which content verification failed

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -75,7 +75,7 @@ class TestCLI(unittest.TestCase):
                     compare_verified = self.compare_json_content(test_files, jfile)
                     print(compare_verified)
                     if not compare_verified:
-                        self.assertTrue(False)
+                        self.assertTrue(False, 'Failed to verify parsing result for ' + jfile)
                     os.remove(test_files)
 
     def test_output_format_date_json(self):


### PR DESCRIPTION
```
tests: print file for which content verification failed

This helps tracking & fixing regressions during development.

Example output:
======================================================================
FAIL: test_content_json (__main__.TestCLI)
----------------------------------------------------------------------
Traceback (most recent call last):
    File "/home/rmilecki/projects/invoice2data/tests/test_cli.py", line 78, in test_content_json
    self.assertTrue(False, 'Failed to verify parsing result for ' + jfile)
AssertionError: False is not true : Failed to verify parsing result for /home/foo/invoice2data/tests/compare/AmazonWebServices.json
```