### PR TITLE
parsers: lines: support "rules" for multiple sets of regexes

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -130,6 +130,10 @@ This parser allows parsing selected invoice section as a set of lines
 sharing some pattern. Those can be e.g. invoice items (good or services)
 or VAT rates.
 
+Some companies may use multiple formats for their line-based data. In
+such cases multiple sets of parsing regexes can be added to the `rules`.
+Results from multiple `rules` get merged into a single array.
+
 It replaces `lines` plugin and should be preferred over it. It allows
 reusing in multiple `fields`.
 
@@ -141,6 +145,17 @@ Example for `fields`:
         start: Item\s+Discount\s+Price$
         end: \s+Total
         line: (?P<description>.+)\s+(?P<discount>\d+.\d+)\s+(?P<price>\d+\d+)
+
+    fields:
+      lines:
+        parser: lines
+        rules:
+          - start: Item\s+Discount\s+Price$
+            end: \s+Total
+            line: (?P<description>.+)\s+(?P<discount>\d+.\d+)\s+(?P<price>\d+\d+)
+          - start: Item\s+Price$
+            end: \s+Total
+            line: (?P<description>.+)\s+(?P<price>\d+\d+)
 
 ### Legacy regexes
 

--- a/src/invoice2data/extract/templates/com/com.amazon.aws.yml
+++ b/src/invoice2data/extract/templates/com/com.amazon.aws.yml
@@ -7,16 +7,18 @@ fields:
   invoice_number: Invoice Number:\s+(\d+)
   partner_name: (Amazon Web Services, Inc\.)
   static_partner_website: aws.amazon.com
+  lines:
+    parser: lines
+    rules:
+      - start: Detail
+        end: \* May include estimated US sales tax
+        first_line: ^    (?P<description>\w+.*)\$(?P<price_unit>\d+\.\d+)
+        line: (.*)\$(\d+\.\d+)
+        last_line: VAT \*\*
 keywords:
   - Amazon Web Services
   - $
   - Invoice
-lines:
-    start: Detail
-    end: \* May include estimated US sales tax
-    first_line: ^    (?P<description>\w+.*)\$(?P<price_unit>\d+\.\d+)
-    line: (.*)\$(\d+\.\d+)
-    last_line: VAT \*\*
 options:
   currency: USD
   date_formats:


### PR DESCRIPTION
```
templates: make Amazon YAML use "rules" for "lines"

This doesn't really change anything and isn't necessary. It however
allows testing "rules" implementation in the "lines" parser.
```
```
lines: support "rules": field for multiple sets of parsing regexes

Sometimes companies use more than 1 format for line-parseable data. They
may e.g. randomly add some extra columns that are used occasionally.

This commit adds "rules" field support to the "lines" parser. It allows
defining multiple sets or regexes ("start", "end", "line" & friends) for
a single field.

Usage of "rules" is optional. Backward compatibility wiht existing
templates is preserved.
```