### PR TITLE
plugins: lines: add support for sets of regexes to legacy syntax

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -130,6 +130,10 @@ This parser allows parsing selected invoice section as a set of lines
 sharing some pattern. Those can be e.g. invoice items (good or services)
 or VAT rates.
 
+Some companies may use multiple formats for their line-based data. In
+such cases multiple sets of parsing regexes can be added to the `rules`.
+Results from multiple `rules` get merged into a single array.
+
 It replaces `lines` plugin and should be preferred over it. It allows
 reusing in multiple `fields`.
 
@@ -141,6 +145,17 @@ Example for `fields`:
         start: Item\s+Discount\s+Price$
         end: \s+Total
         line: (?P<description>.+)\s+(?P<discount>\d+.\d+)\s+(?P<price>\d+\d+)
+
+    fields:
+      lines:
+        parser: lines
+        rules:
+          - start: Item\s+Discount\s+Price$
+            end: \s+Total
+            line: (?P<description>.+)\s+(?P<discount>\d+.\d+)\s+(?P<price>\d+\d+)
+          - start: Item\s+Price$
+            end: \s+Total
+            line: (?P<description>.+)\s+(?P<price>\d+\d+)
 
 ### Legacy regexes
 

--- a/src/invoice2data/extract/plugins/lines.py
+++ b/src/invoice2data/extract/plugins/lines.py
@@ -10,6 +10,14 @@ from .. import parsers
 
 
 def extract(self, content, output):
-    lines = parsers.lines.parse(self, "lines", self["lines"], content)
-    if lines is not None:
+    lines = []
+
+    rules = self['lines']
+    if not isinstance(self['lines'], list):
+        rules = [rules]
+
+    for rule in rules:
+        lines += parsers.lines.parse(self, "lines", rule, content)
+
+    if len(lines):
         output["lines"] = lines

--- a/src/invoice2data/extract/templates/com/com.amazon.aws.yml
+++ b/src/invoice2data/extract/templates/com/com.amazon.aws.yml
@@ -7,16 +7,18 @@ fields:
   invoice_number: Invoice Number:\s+(\d+)
   partner_name: (Amazon Web Services, Inc\.)
   static_partner_website: aws.amazon.com
+  lines:
+    parser: lines
+    rules:
+      - start: Detail
+        end: \* May include estimated US sales tax
+        first_line: ^    (?P<description>\w+.*)\$(?P<price_unit>\d+\.\d+)
+        line: (.*)\$(\d+\.\d+)
+        last_line: VAT \*\*
 keywords:
   - Amazon Web Services
   - $
   - Invoice
-lines:
-    start: Detail
-    end: \* May include estimated US sales tax
-    first_line: ^    (?P<description>\w+.*)\$(?P<price_unit>\d+\.\d+)
-    line: (.*)\$(\d+\.\d+)
-    last_line: VAT \*\*
 options:
   currency: USD
   date_formats:


### PR DESCRIPTION
```
If someone insists on using the old syntax for the "lines" plugin this
change will allow using multiple sets of parsing rules.

Example:
lines:
    - start: Item\s+Discount\s+Price$
    end: \s+Total
    line: (?P<description>.+)\s+(?P<discount>\d+.\d+)\s+(?P<price>\d+\d+)
    - start: Item\s+Price$
    end: \s+Total
    line: (?P<description>.+)\s+(?P<price>\d+\d+)
```