### PR TITLE
Support parsing plain text invoices (like invoice.txt)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ won't parse tables in PDF correctly.
 Basic usage. Process PDF files and write result to CSV.
 
 - `invoice2data invoice.pdf`
+- `invoice2data invoice.txt`
 - `invoice2data *.pdf`
 
 Choose any of the following input readers:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A command line tool and Python library to support your accounting
 process.
 
 1. extracts text from PDF files using different techniques, like
-   `pdftotext`, `pdfminer` or OCR -- `tesseract`, `tesseract4` or
+   `pdftotext`, `text`, `pdfminer` or OCR -- `tesseract`, `tesseract4` or
    `gvision` (Google Cloud Vision).
 2. searches for regex in the result using a YAML-based template system
 3. saves results as CSV, JSON or XML or renames PDF files to match the content.
@@ -54,6 +54,7 @@ Basic usage. Process PDF files and write result to CSV.
 Choose any of the following input readers:
 
 - pdftotext `invoice2data --input-reader pdftotext invoice.pdf`
+- pdftotext `invoice2data --input-reader text invoice.txt`
 - tesseract `invoice2data --input-reader tesseract invoice.pdf`
 - pdfminer.six `invoice2data --input-reader pdfminer invoice.pdf`
 - tesseract4 `invoice2data --input-reader tesseract4 invoice.pdf`

--- a/src/invoice2data/input/text.py
+++ b/src/invoice2data/input/text.py
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: MIT
+
+def to_text(path):
+    with open(path, 'r') as f:
+        return f.read().encode('utf-8')

--- a/src/invoice2data/main.py
+++ b/src/invoice2data/main.py
@@ -35,7 +35,7 @@ input_mapping = {
 output_mapping = {"csv": to_csv, "json": to_json, "xml": to_xml, "none": None}
 
 
-def extract_data(invoicefile, templates=None, input_module=pdftotext):
+def extract_data(invoicefile, templates=None, input_module=None):
     """Extracts structured data from PDF/image invoices.
 
     This function uses the text extracted from a PDF file or image and
@@ -81,6 +81,13 @@ def extract_data(invoicefile, templates=None, input_module=pdftotext):
         templates = read_templates()
 
     # print(templates[0])
+
+    if input_module is None:
+        if invoicefile.lower().endswith('.txt'):
+            input_module = text
+        else:
+            input_module = pdftotext
+
     extracted_str = input_module.to_text(invoicefile).decode("utf-8")
     if not isinstance(extracted_str, str) or not extracted_str.strip():
         logger.error("Failed to extract text from %s using %s", invoicefile, input_module.__name__)
@@ -111,8 +118,7 @@ def create_parser():
     parser.add_argument(
         "--input-reader",
         choices=input_mapping.keys(),
-        default="pdftotext",
-        help="Choose text extraction function. Default: pdftotext",
+        help="Choose text extraction function. Default: auto-detect between text & pdftotext",
     )
 
     parser.add_argument(
@@ -199,7 +205,7 @@ def main(args=None):
     else:
         logging.basicConfig(level=logging.INFO, format="%(message)s")
 
-    input_module = input_mapping[args.input_reader]
+    input_module = input_mapping[args.input_reader] if args.input_reader is not None else None
     output_module = output_mapping[args.output_format]
 
     templates = []

--- a/src/invoice2data/main.py
+++ b/src/invoice2data/main.py
@@ -12,6 +12,7 @@ from .input import pdfminer_wrapper
 from .input import tesseract
 from .input import tesseract4
 from .input import gvision
+from .input import text
 
 from invoice2data.extract.loader import read_templates
 
@@ -28,6 +29,7 @@ input_mapping = {
     "tesseract4": tesseract4,
     "pdfminer": pdfminer_wrapper,
     "gvision": gvision,
+    "text": text,
 }
 
 output_mapping = {"csv": to_csv, "json": to_json, "xml": to_xml, "none": None}
@@ -48,7 +50,7 @@ def extract_data(invoicefile, templates=None, input_module=pdftotext):
         path of electronic invoice file in PDF,JPEG,PNG (example: "/home/duskybomb/pdf/invoice.pdf")
     templates : list of instances of class `InvoiceTemplate`, optional
         Templates are loaded using `read_template` function in `loader.py`
-    input_module : {'pdftotext', 'pdfminer', 'tesseract'}, optional
+    input_module : {'pdftotext', 'pdfminer', 'tesseract', 'text'}, optional
         library to be used to extract text from given `invoicefile`,
 
     Returns

--- a/tests/compare/Orlen.json
+++ b/tests/compare/Orlen.json
@@ -1,0 +1,19 @@
+[
+    {
+        "issuer": "Polski Koncern Naftowy ORLEN spółka akcyjna",
+        "date": "2021-01-01",
+        "invoice_number": "F",
+        "amount": 316.83,
+        "vat": 7740001454,
+        "sums":[
+            {
+              "net": 257.59,
+              "rate": 23,
+              "vat": 59.24,
+              "gross": 316.83
+            }
+        ],
+        "currency": "PLN",
+        "desc": "Invoice from Polski Koncern Naftowy ORLEN spółka akcyjna"
+    }
+]

--- a/tests/compare/Orlen.txt
+++ b/tests/compare/Orlen.txt
@@ -1,0 +1,36 @@
+Faktura nr: F 1234K20/1234/12                                                            Data wystawienia: 2021-01-01
+Sprzedawca: Polski Koncern Naftowy ORLEN S.A.
+NIP:               774-00-01-454
+Adres:             Chemików 7 09-411 Płock
+                   Polski Koncern Naftowy ORLEN S.A.
+                   Stacja Paliw Nr 4445
+                   58-100 Słotwina
+                   Słotwina 62x
+Nabywca:           GŁÓWNY URZĄD STATYSTYCZNY
+NIP:               5261040828
+Adres:             Aleja Niepodległości 208 00-925 Warszawa
+
+
+                                                                               Cena
+                                                         Cena      Wartość                Wartość    VAT                 Wartość
+ Lp Nazwa towaru                       Jm   Ilość [jm]                       brutto po                   Kwota VAT
+                                                         brutto    rabatu                  netto     [%]                  brutto
+                                                                              rabacie
+
+1   EFECTA 95 CN27101245                l     54,910        5,79      1,10       5,77       257,59       23      59,24     316,83
+
+
+
+                                                                      Razem:         257,59                   59,24      316,83
+                                                                       w tym:         257,59        23        59,24       316,83
+
+
+
+Należność ogółem: 316,83 PLN
+
+Słownie: trzysta szesnaście PLN, 83/100
+
+
+Do dokumentów: Dok. wydania: 1234567 Dok.fisk.nr 12345 z dnia 2021-01-01
+Zapłacono: Aplikacja mobilna ORLEN Pay
+Faktura wygenerowana automatycznie

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -62,14 +62,14 @@ class TestCLI(unittest.TestCase):
     # TODO: parse output files instaed of comparing them byte-by-byte.
 
     def test_content_json(self):
-        pdf_files = get_sample_files('.pdf')
+        input_files = get_sample_files(('.pdf', '.txt'))
         json_files = get_sample_files('.json')
         test_files = 'test_compare.json'
-        for pfile in pdf_files:
+        for ifile in input_files:
             for jfile in json_files:
-                if pfile[:-4] == jfile[:-5]:
+                if ifile[:-4] == jfile[:-5]:
                     args = self.parser.parse_args(
-                        ['--output-name', test_files, '--output-format', 'json', pfile]
+                        ['--output-name', test_files, '--output-format', 'json', ifile]
                     )
                     main(args)
                     compare_verified = self.compare_json_content(test_files, jfile)
@@ -145,7 +145,7 @@ class TestCLI(unittest.TestCase):
                     i += 1
 
         shutil.rmtree('tests/copy_test/', ignore_errors=True)
-        self.assertEqual(i, len(get_sample_files('.json')))
+        self.assertEqual(i, len(get_sample_files('.pdf')))
         '''
         if i != len(self._get_test_file_json_path()):
             print(i)
@@ -187,7 +187,7 @@ class TestCLI(unittest.TestCase):
                 root, ext = os.path.splitext(file)
                 if root not in data:
                     data[root] = {}
-                if file.endswith('.pdf'):
+                if file.endswith(('.pdf', '.txt')):
                     data[root]['input_fpath'] = os.path.join(path, file)
                 if file.endswith('.json'):
                     with open(os.path.join(path, file), 'r') as f:


### PR DESCRIPTION
```
tests: add test for parsing Orlen invoices

This is the first test invoice in text format.
```
```
tests: add support for comparing text input files with expected output

Now that invoice2data supports plain text invoices (with the "text"
input module) we should also include some tests for it to make sure this
feature is properly maintained.
```
```
Add very basic (pdftotext vs. text) auto-detection of input file format

We can't always detect the best input module as there are e.g. multiple
ones for handling OCR. We can however decide between "text" and
"pdftotext" as default.

This makes using invoice2data a bit easier for parsing plain text
invoices.
```
```
input: add support for plain text

This extends possible invoice2data usage for dealing with plain text
documents.

It may be also useful for:
1. Debugging - when reporter provides parsed PDF content only
2. Testing - it may be easier to write more test for plain text files

Signed-off-by: Rafał Miłecki <rafal@milecki.pl>
```