### PR TITLE
tests: prepare for custom invoices and templates

### DIFF
--- a/tests/custom/basic.json
+++ b/tests/custom/basic.json
@@ -1,0 +1,10 @@
+[
+    {
+        "issuer": "Basic Test",
+        "date": "2022-09-27",
+        "invoice_number": "0999/09/2022",
+        "amount": 123.45,
+        "currency": "EUR",
+        "desc": "Invoice from Basic Test"
+    }
+]

--- a/tests/custom/basic.txt
+++ b/tests/custom/basic.txt
@@ -1,0 +1,4 @@
+Issue date: 2022-09-27
+Issuer: Basic Test
+Invoice number: 0999/09/2022
+Total: 123.45 EUR

--- a/tests/custom/templates/basic.yml
+++ b/tests/custom/templates/basic.yml
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: MIT
+issuer: Basic Test
+keywords:
+  - Basic Test
+fields:
+  date:
+    parser: regex
+    regex: Issue date:\s*(\d{4}-\d{2}-\d{2})
+    type: date
+  invoice_number:
+    parser: regex
+    regex: Invoice number:\s*([\d/]+)
+  amount:
+    parser: regex
+    regex: Total:\s*(\d+\.\d\d)
+    type: float
+options:
+  currency: EUR
+  date_formats:
+    - '%Y-%m-%d'
+  decimal_separator: '.'

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -10,6 +10,8 @@
 
 # https://docs.python.org/3.10/library/unittest.html#test-cases
 
+import datetime
+import json
 import unittest
 import pkg_resources
 import os
@@ -36,6 +38,25 @@ class TestExtraction(unittest.TestCase):
     def test_internal_pdfs(self):
         folder = pkg_resources.resource_filename(__name__, 'pdfs')
         self._run_test_on_folder(folder)
+
+    def test_custom_invoices(self):
+        directory = os.path.dirname("tests/custom/templates/")
+        templates = read_templates(directory)
+
+        for path, subdirs, files in os.walk(pkg_resources.resource_filename(__name__, 'custom')):
+            for file in files:
+                if file.endswith(('.pdf', '.txt')):
+                    ifile = os.path.join(path, file)
+                    jfile = os.path.join(path, file[:-4] + '.json')
+
+                    res = extract_data(ifile, templates)
+                    for key, value in res.items():
+                        if type(value) is datetime.datetime:
+                            res[key] = value.strftime('%Y-%m-%d')
+                    res = [res]
+                    with open(jfile) as json_file:
+                        ref_json = json.load(json_file)
+                        self.assertTrue(res == ref_json, 'Unexpected data extracted from ' + ifile)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
```
There is limited amount of real invoices included in the project and not
everything can be tested using them. To extend tests coverage add place
for storing custom invoices & templates. That way we can write more
complex templates that use more complex syntax.
```