### PR TITLE
Support "priority" and add 2 templates for InsERT-software-generated invoices

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -301,6 +301,21 @@ options and their defaults are:
   different fields, you can supply a list here. The extraction will
   fail if not all fields are matched.
 
+### Priority
+
+In case of multiple templates matching single invoice the one with the
+highest priority will be used. Default `priority` value (assigned if
+missing) is 5.
+
+This property needs to be specified only when designing some generic or
+very specific templates.
+
+Suggested values:
+
+- 0-4: accounting/invoice software specific template
+- 5: company specific template
+- 6-10: company department/unit specific template
+
 ### Example of template using most options
 
     issuer: Free Mobile

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -96,8 +96,9 @@ Optional properties:
 
 - `type` (if present must be one of: `int`, `float`, `date`) -results
   in parsing every matched value to a specified type
-- `group` (if present must be `sum`) - results in grouping all matched
-  values using specified method
+- `group` (if present must be one of: `sum`, `min`, `max`, `first`,
+  `last`) - specifies grouping function (defines what value to return in
+  case of multiple matches)
 
 Example for `regex`:
 

--- a/src/invoice2data/extract/loader.py
+++ b/src/invoice2data/extract/loader.py
@@ -107,6 +107,9 @@ def read_templates(folder=None):
                 elif type(tpl["exclude_keywords"]) is not list:
                     tpl["exclude_keywords"] = [tpl["exclude_keywords"]]
 
+                if 'priority' not in tpl.keys():
+                    tpl['priority'] = 5
+
                 output.append(InvoiceTemplate(tpl))
 
     logger.info("Loaded %d templates from %s", len(output), folder)

--- a/src/invoice2data/extract/parsers/regex.py
+++ b/src/invoice2data/extract/parsers/regex.py
@@ -49,6 +49,14 @@ def parse(template, field, settings, content, legacy=False):
     if "group" in settings:
         if settings["group"] == "sum":
             result = sum(result)
+        elif settings["group"] == "min":
+            result = min(result)
+        elif settings["group"] == "max":
+            result = max(result)
+        elif settings["group"] == "first":
+            result = result[0]
+        elif settings["group"] == "last":
+            result = result[-1]
         else:
             logger.warning("Unsupported grouping method: " + settings["group"])
             return None

--- a/src/invoice2data/extract/templates/pl/pl.insert.subiekt-gt.yml
+++ b/src/invoice2data/extract/templates/pl/pl.insert.subiekt-gt.yml
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: MIT
+keywords:
+  - 'Miejsce wystawienia:'
+  - 'Data wystawienia:'
+  - 'Sprzedawca:'
+  - 'Nabywca:'
+  - 'według stawki VAT'
+  - 'Razem do zapłaty:'
+  - 'Wystawił\(a\)'
+  - 'Odebrał\(a\)'
+  - 'Podpis osoby upoważnionej'
+fields:
+  issuer:
+    parser: regex
+    regex: Sprzedawca:.*\n(.*?)\s{3,}
+  vatin:
+    parser: regex
+    regex: NIP:\s+(\d{10})
+    type: int
+    group: first
+  date:
+    parser: regex
+    regex:
+      - Data wystawienia:\n.*(\d{2}\.\d{2}\.\d{4})
+      - Data wystawienia:\n.*(\d{4}-\d{2}-\d{2})
+    type: date
+  invoice_number:
+    parser: regex
+    regex: Faktura VAT\s+(.*?)\s+oryginał
+  amount:
+    parser: regex
+    regex: Razem do zapłaty:\s+([\d\s]+,[\d][\d])
+    type: float
+  nrb:
+    parser: regex
+    regex: PLN:\s+([0-9]{2}(?:\s?[0-9]{4}){6})
+options:
+  currency: PLN
+  date_formats:
+    - '%d.%m.%Y'
+    - '%Y-%m-%d'
+  decimal_separator: ','
+priority: 3

--- a/src/invoice2data/extract/templates/pl/pl.insert.subiekt-nexo.yml
+++ b/src/invoice2data/extract/templates/pl/pl.insert.subiekt-nexo.yml
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: MIT
+keywords:
+  - 'InsERT nexo'
+fields:
+  issuer:
+    parser: regex
+    regex: Sprzedawca.*\n(.*?)\s{3,}
+  vatin:
+    parser: regex
+    regex: NIP:\s+(\d{10})
+    type: int
+    group: first
+  date:
+    parser: regex
+    regex: Data wystawienia\s+(\d{2}-\d{2}-\d{4})
+    type: date
+  invoice_number:
+    parser: regex
+    regex: Faktura VAT sprzedaży\s+(.*)
+    group: first
+  amount:
+    parser: regex
+    regex: Razem do zapłaty:\s+([\d\s]+,[\d][\d])
+    type: float
+  nrb:
+    parser: regex
+    regex: PL\s+([0-9]{2}(?:\s?[0-9]{4}){6})
+options:
+  currency: PLN
+  date_formats:
+    - '%d-%m-%Y'
+  decimal_separator: ','
+priority: 3

--- a/src/invoice2data/main.py
+++ b/src/invoice2data/main.py
@@ -107,6 +107,7 @@ def extract_data(invoicefile, templates=None, input_module=None):
     optimized_str = t.prepare_input(extracted_str)
     return t.extract(optimized_str, invoicefile, input_module)
 
+
 def create_parser():
     """Returns argument parser """
 


### PR DESCRIPTION
```
templates: pl: add templates for InsERT's software issued invoices

InsERT is one of the most popular Polish accounting software company.
They have two very common softwares:
1. Subiekt nexo
2. Subiekt GT

Add 2 templates to parse invoices generated by above softwares. Those
templates are software-specific so they have priority set to 3.

This allows parsing a lot invoices issued in Poland.
```
```
Regex: support more grouping functions

In case of multiple matches we only had an option to return a sum of
numeric values. Add more functions.
```
```
Add "priority" support for templates

In case of multiple templates matching given invoice - choose the one
with the highest "priority" value. To provide proper support for
prioritizing AND existing templates (backward compatibility) the default
value 5 is assumed in case "priority" property is missing.

This feature can be used for writing more generic as well as more
specific templates. So far all templates were assumed to be
company-specific. With this change we can have:
1. Invoice-generating software specific templates
2. In-company varying templates

This feature may be very useful for:
1. Countries with just few very popular accounting software applications
2. Big companies with multiple departments adding some invoice details
```