### PR TITLE
Fix over indentation in debug logger

### DIFF
--- a/src/invoice2data/extract/invoice_template.py
+++ b/src/invoice2data/extract/invoice_template.py
@@ -156,8 +156,7 @@ class InvoiceTemplate(OrderedDict):
         Given a template file and a string, extract matching data fields.
         """
 
-        logger.debug("START optimized_str ========================")
-        logger.debug(optimized_str)
+        logger.debug("START optimized_str ========================\n" + optimized_str)
         logger.debug("END optimized_str ==========================")
         logger.debug(
             "Date parsing: languages=%s date_formats=%s",

--- a/src/invoice2data/main.py
+++ b/src/invoice2data/main.py
@@ -95,8 +95,7 @@ def extract_data(invoicefile, templates=None, input_module=None):
         logger.error("Failed to extract text from %s using %s", invoicefile, input_module.__name__)
         return False
 
-    logger.debug("START pdftotext result ===========================")
-    logger.debug(extracted_str)
+    logger.debug("START pdftotext result ===========================\n" + extracted_str)
     logger.debug("END pdftotext result =============================")
 
     for t in templates:


### PR DESCRIPTION
Small cosmetic change:
The firstline of the extracted text and optimized string is over indented in the debug logger.

Before this PR:
```
DEBUG:invoice2data.extract.invoice_template:START optimized_str ========================
DEBUG:invoice2data.extract.invoice_template:   Ø Saeco
           Factuuradres                                          Afleveradres
           Strategic Corp                                        bosd
           T.a.v. bosd                                           Fakestreet 46
           Fakestreet 46                                         3500 MJ Utrecht
           3500 MJ Utrecht                                       Nederland
           Nederland

```

After:
```
DEBUG:invoice2data.extract.invoice_template:START optimized_str ========================
DEBUG:invoice2data.extract.invoice_template:
   Ø Saeco
           Factuuradres                                          Afleveradres
           Strategic Corp                                        bosd
           T.a.v. bosd                                           Fakestreet 46
           Fakestreet 46                                         3500 MJ Utrecht
           3500 MJ Utrecht                                       Nederland
           Nederland

```
(This is important because the template builder modle reads this string) 