### PR TITLE
Fix Flake8 A001 variable str is shadowing a python builtin

### DIFF
--- a/src/invoice2data/input/pdfminer_wrapper.py
+++ b/src/invoice2data/input/pdfminer_wrapper.py
@@ -51,6 +51,6 @@ def to_text(path):
         for page in pages:
             interpreter.process_page(page)
     device.close()
-    str = retstr.getvalue()
+    out = retstr.getvalue()
     retstr.close()
-    return str.encode("utf-8")
+    return out.encode("utf-8")


### PR DESCRIPTION
Quick fix for:
Flake8 A001 variable str is shadowing a python builtin.


Looking at the code, some more attention might be wanted:
- Python 2 compatability
- -Restringing required
- Make input parameters configurable
- Catchtimeout errors
- Try import to check if pdfminer.six is available
- pdfminer is known to be slown down by all the logger messages they put out. So best to silence them
- - There are some open issues mentioning the pdfminer input parser.

But I'll leave that for some other PR :)