### PR TITLE
templates: de: improve parsing QualityHosting lines

### DIFF
--- a/src/invoice2data/extract/templates/de/de.qualityhosting.yml
+++ b/src/invoice2data/extract/templates/de/de.qualityhosting.yml
@@ -12,6 +12,7 @@ lines:
   end: 'Total EUR'
   first_line: '\s+(?P<pos>\d+)\s+(?P<qty>\d+)\s+(?P<desc>.{,70})\s+(?P<price>\d+,\d+)'
   line: '^\s+(?P<desc>.+)$'
+  last_line: '^\s+(?P<desc>\d\d\.\d\d\.\d\d-\d\d\.\d\d\.\d\d)$'
   types:
       qty: float
       price: float

--- a/tests/compare/QualityHosting.json
+++ b/tests/compare/QualityHosting.json
@@ -41,13 +41,13 @@
             {
                 "pos": "6",
                 "qty": 1.0,
-                "desc": "Small Business QualityExchange 2010\nGrundgebühr pro Einheit\nDienst: OUDJQ_jauernik\n01.05.14-31.05.14\nQualityHosting AG - Uferweg 40-42 - D-63571 Gelnhausen\niViveLabs Ltd.\n93B Sai Yu Chung\nYuen Long, N.T.\nHong Kong\nPos.            Menge      Beschreibung                                                            Rabatt %     VK-Preis     Zeilenbetrag\nOhne      Ohne MwSt.\nMwSt.",
+                "desc": "Small Business QualityExchange 2010\nGrundgebühr pro Einheit\nDienst: OUDJQ_jauernik\n01.05.14-31.05.14",
                 "price": 5.39
             },
             {
                 "pos": "7",
                 "qty": 1.0,
-                "desc": "Small Business StandardExchange 2010\nGrundgebühr pro Einheit\nDienst: OUDJQ_office\n01.05.14-31.05.14\n",
+                "desc": "Small Business StandardExchange 2010\nGrundgebühr pro Einheit\nDienst: OUDJQ_office\n01.05.14-31.05.14",
                 "price": 3.89
             }
         ],


### PR DESCRIPTION
```
A single QualityHosting invoice position spans across multiple lines.
For that reason it uses a very generic RegEx for middle lines:
line: '^\s+(?P<desc>.+)$'

That doesn't work well with multi-page invoices. It's because above
RegEx matches page footer lines. That results in footer content getting
extracted as invoice line "desc".

Improve that situation by adding "last_line" RegEx matching position
last line. That prevents parsing lines between last and first lines
(e.g. footer content).
```