### PR TITLE
[REM] unidecode library

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,6 @@ install_requires =
   pillow
   pyyaml
   dateparser
-  unidecode
 
 [options.extras_require]
 test = pytest; pytest-cov; flake8; pdfminer.six; pdfplumber; tox

--- a/src/invoice2data/extract/invoice_template.py
+++ b/src/invoice2data/extract/invoice_template.py
@@ -6,7 +6,7 @@ Templates are initially read from .yml files and then kept as class.
 
 import re
 import dateparser
-from unidecode import unidecode
+import unicodedata
 import logging
 from collections import OrderedDict
 from . import parsers
@@ -79,7 +79,7 @@ class InvoiceTemplate(OrderedDict):
 
         # Remove accents
         if self.options["remove_accents"]:
-            optimized_str = unidecode(optimized_str)
+            optimized_str = unicodedata.normalize('NFKC', optimized_str).encode('ascii', 'ignore').decode('ascii')
 
         # convert to lower case
         if self.options["lowercase"]:


### PR DESCRIPTION
As discussed in #435 the unidecode lib uses a GPL-2.0 inclusive license.

Remove unidecode library for a python native solution.
