### PR TITLE
Add template encoding option

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -58,11 +58,11 @@ All the regex `fields` you need extracted. Required fields are `amount`,
 `date`, `invoice_number`. It's up to you, if you need more fields
 extracted. Each field can be defined as:
 
-- an **associative array** with 
-`parser` (required) specifying parsing method and 
-`area` (optional) specifying the region of the pdf to search. 
-This takes the following arguments: `f` (first page), `l` (last page), `x` (top-left x-coord), `y` (top-left y-coord), 
-`r` (resolution), `W` (width in pixels) and `H` (height in pixels). When setting your region, ensure the resolution in your 
+- an **associative array** with
+`parser` (required) specifying parsing method and
+`area` (optional) specifying the region of the pdf to search.
+This takes the following arguments: `f` (first page), `l` (last page), `x` (top-left x-coord), `y` (top-left y-coord),
+`r` (resolution), `W` (width in pixels) and `H` (height in pixels). When setting your region, ensure the resolution in your
 image editor matches the resolution specified for `r` in this option. If not, it will not line up properly.
 - a single regex with one capturing group
 - an array of regexes
@@ -300,6 +300,10 @@ options and their defaults are:
   date, amount, invoice\_number and issuer. If you wish to extract
   different fields, you can supply a list here. The extraction will
   fail if not all fields are matched.
+- `encoding` (default: None): in some cases the automatic template encoding
+  detection fails and the loaded template yields unexpected parsing results.
+  Then you can specify the actual template encoding.
+
 
 ### Example of template using most options
 
@@ -326,6 +330,7 @@ options and their defaults are:
       replace:
         - ['e´ ', 'é']
         - ['\s{5,}', ' ']
+      encoding: 'utf-8'
 
 
 ## Steps to add new template

--- a/src/invoice2data/extract/templates/nl/nl.begra.yml
+++ b/src/invoice2data/extract/templates/nl/nl.begra.yml
@@ -9,7 +9,7 @@ fields:
   invoice_number: Factuurnr[.]\s+(\S+)
   static_vat: NL818038524B01
   bic: SWIFT[\/]BIC[:]\s+(\w{8,11})
-  iban: [A-Z]{2}\d{2}?\w{4}?\d{4}?\d{4}?\d{0,2}
+  iban: '[A-Z]{2}\d{2}?\w{4}?\d{4}?\d{4}?\d{0,2}'
   telephone:
     parser: regex
     regex: '[+]\d{11}'

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,0 +1,77 @@
+import os
+import shutil
+
+import chardet
+import pytest
+
+from invoice2data.extract.loader import (
+    detect_template_encoding,
+    get_templatefiles,
+    read_templates,
+)
+
+
+@pytest.fixture(autouse=True)
+def prepare_template(templatefile: str) -> None:
+    with open(templatefile, "w", encoding="utf-8") as templatefile:
+        templatefile.write(template_with_single_special_char)
+
+
+@pytest.fixture
+def templatedirectory() -> str:
+    templatedirectory = os.path.dirname("tests/templatedirectory/")
+    os.makedirs(templatedirectory)
+
+    yield templatedirectory
+
+    shutil.rmtree(templatedirectory, ignore_errors=True)
+
+
+@pytest.fixture
+def templatefile(templatedirectory: str) -> str:
+    return os.path.join(templatedirectory, "template.yml")
+
+
+def test_chardet_detect_template_encoding_is_not_utf8(templatefile: str):
+    with open(templatefile, "rb") as file:
+        detection_result = chardet.detect(file.read())
+
+    assert detection_result["encoding"] != "utf-8"
+
+
+def test_detect_template_encoding_is_utf8(templatefile: str):
+    assert detect_template_encoding(templatefile) == "utf-8"
+
+
+def test_get_templatefiles(templatedirectory: str, templatefile: str):
+    assert get_templatefiles(templatedirectory) == {templatefile: "template.yml"}
+
+
+def test_template_with_single_specialchar_is_loaded_as_utf8(templatedirectory: str):
+    templates = read_templates(templatedirectory)
+
+    assert templates[0]["fields"]["single_specialchar"]["value"] == "ä"
+
+
+template_with_single_special_char = """
+issuer: Basic Test
+keywords:
+  - Basic Test
+fields:
+  date:
+    parser: regex
+    regex: Issue date:\s*(\d{4}-\d{2}-\d{2})
+    type: date
+  invoice_number:
+    parser: regex
+    regex: Invoice number:\s*([\d/]+)
+  amount:
+    parser: regex
+    regex: Total:\s*(\d+\.\d\d)
+    type: float
+  single_specialchar:
+    parser: static
+    value: ä
+options:
+  encoding: utf-8
+"""


### PR DESCRIPTION
Fixes #445.

I have implemented a new `option` to specify the actual template encoding and extended the loader mechanism. Also did some refactoring in the `read_templates` function for better readability and testability.