### PR TITLE
Fix nl.begra.yml formatting

### DIFF
--- a/src/invoice2data/extract/templates/nl/nl.begra.yml
+++ b/src/invoice2data/extract/templates/nl/nl.begra.yml
@@ -2,14 +2,14 @@
 # SPDX-License-Identifier: MIT
 issuer: Begra Magazijninrichting B.V.
 fields:
-  amount: Totaal EUR incl[.] btw\s+(\d{1,4}[,]\d{2})
+  amount: 'Totaal EUR incl[.] btw\s+(\d{1,4}[,]\d{2})'
   amount_tax: BTW\s+(\d{1,4}[,]\d{2})
   amount_untaxed: Totaal EUR excl[.] btw\s+(\d{1,4}[,]\d{2})
   date: Factuurdatum\s+(\d{1,2}[.]\s\w+\s\d{4})
   invoice_number: Factuurnr[.]\s+(\S+)
   static_vat: NL818038524B01
   bic: SWIFT[\/]BIC[:]\s+(\w{8,11})
-  iban: [A-Z]{2}\d{2}?\w{4}?\d{4}?\d{4}?\d{0,2}
+  iban: '[A-Z]{2}\d{2}?\w{4}?\d{4}?\d{4}?\d{0,2}'
   telephone:
     parser: regex
     regex: '[+]\d{11}'


### PR DESCRIPTION
```
This fixes:

Failed to load nl.begra.yml template:
while parsing a block mapping
  in "<unicode string>", line 5, column 3:
      amount: Totaal EUR incl[.] btw\s ...
      ^
expected <block end>, but found '{'
  in "<unicode string>", line 12, column 14:
      iban: [A-Z]{2}\d{2}?\w{4}?\d{4}?\d{4}?\d{0,2}
                 ^
```