### PR TITLE
Treat all YAML templates files as UTF-8 encoded

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,6 @@ setup_requires =
   pytest-runner
   setuptools_git
 install_requires =
-  chardet
   pillow
   pyyaml
   dateparser

--- a/src/invoice2data/extract/loader.py
+++ b/src/invoice2data/extract/loader.py
@@ -11,11 +11,8 @@ from collections import OrderedDict
 import logging
 from .invoice_template import InvoiceTemplate
 import codecs
-import chardet
 
 logger = logging.getLogger(__name__)
-
-logging.getLogger("chardet").setLevel(logging.WARNING)
 
 
 # borrowed from http://stackoverflow.com/a/21912744
@@ -86,10 +83,8 @@ def read_templates(folder=None):
     for path, subdirs, files in os.walk(folder):
         for name in sorted(files):
             if name.endswith(".yml"):
-                with open(os.path.join(path, name), "rb") as f:
-                    encoding = chardet.detect(f.read())["encoding"]
                 with codecs.open(
-                    os.path.join(path, name), encoding=encoding
+                    os.path.join(path, name), encoding="utf-8"
                 ) as template_file:
                     try:
                         tpl = ordered_load(template_file.read())

--- a/tests/common.py
+++ b/tests/common.py
@@ -3,7 +3,6 @@ import pkg_resources
 import logging
 
 # Reduce log level of various modules
-logging.getLogger('chardet').setLevel(logging.WARNING)
 logging.getLogger('pdfminer').setLevel(logging.WARNING)
 
 


### PR DESCRIPTION
```
Treat all YAML templates files as UTF-8 encoded

Encoding detection based on chardet is unreliable. For UTF-8 encoded
files with few non-ASCII chars it often fails to detect UTF-8. That
results in invoices not being parsed correctly.

Read every YAML file as UTF-8 encoded. It is used by all project
internal templates. It should be used by all external ones too.

FWIW YAML documentation also says that every *processor* must support
the UTF-8, UTF-16 and UTF-32:
https://yaml.org/spec/1.2.2/#52-character-encodings
```