### PR TITLE
parsers: regex: check if regex from template is a string

### DIFF
--- a/src/invoice2data/extract/parsers/regex.py
+++ b/src/invoice2data/extract/parsers/regex.py
@@ -30,6 +30,9 @@ def parse(template, field, settings, content, legacy=False):
 
     result = []
     for regex in regexes:
+        if not isinstance(regex, str):
+            logger.warning("Field \"%s\" regex is not a string (%s)", field, str(regex))
+            continue
         matches = re.findall(regex, content)
         logger.debug("field=%s | regex=%s | matches=%s", field, settings["regex"], matches)
         if matches:


### PR DESCRIPTION
```
Incorrectly formatted templates may result in passing OrderedDict as a
regex. That makes re.findall fail like:

  File "/home/foo/invoice2data/src/invoice2data/extract/parsers/regex.py", line 33, in parse
    matches = re.findall(regex, content)
  File "/usr/lib64/python3.6/re.py", line 222, in findall
    return _compile(pattern, flags).findall(string)
  File "/usr/lib64/python3.6/re.py", line 289, in _compile
    p, loc = _cache[type(pattern), pattern, flags]
TypeError: unhashable type: 'collections.OrderedDict'

Handle such case by displaying a meaningful warning.
```