### PR TITLE
output: to_json: improve formatting dict-ionaries

### DIFF
--- a/src/invoice2data/output/to_json.py
+++ b/src/invoice2data/output/to_json.py
@@ -3,10 +3,18 @@ import datetime
 import codecs
 
 
-def myconverter(o):
-    """function to serialise datetime"""
-    if isinstance(o, datetime.datetime):
-        return o.__str__()
+def format_item(item, date_format):
+    if isinstance(item, datetime.date):
+        return item.strftime(date_format)
+    elif isinstance(item, datetime.date):
+        return item.__str__()
+    elif isinstance(item, dict):
+        for k, v in item.items():
+            item[k] = format_item(v, date_format)
+    elif isinstance(item, list):
+        for k, v in enumerate(item):
+            item[k] = format_item(v, date_format)
+    return item
 
 
 def write_to_file(data, path, date_format="%Y-%m-%d"):
@@ -34,21 +42,20 @@ def write_to_file(data, path, date_format="%Y-%m-%d"):
         >>> to_json.write_to_file(data, "invoice.json")
 
     """
+    for invoice in data:
+        for k, v in invoice.items():
+            invoice[k] = format_item(v, date_format)
+
     if path.endswith(".json"):
         filename = path
     else:
         filename = path + ".json"
 
     with codecs.open(filename, "w", encoding="utf-8") as json_file:
-        for line in data:
-            for k, v in line.items():
-                if k.startswith("date") or k.endswith("date"):
-                    line[k] = v.strftime(date_format)
         json.dump(
             data,
             json_file,
             indent=4,
             sort_keys=False,
-            default=myconverter,
             ensure_ascii=False,
         )


### PR DESCRIPTION
```
Previous code was:
1. Expecting every field with "date" in its name to be datetime.date
2. Ignoring datetime.date in other fields

That didn't match possible parsing results after all recent changes:
1. Any field can contain a date
2. Fields with "date" in their names can be lists

This change rewrites to_json to allow dealing with datetime.date in any
field at any depth level.

This also fixes possible issue like:

Traceback (most recent call last):
    File "/opt/homebrew/bin/invoice2data", line 8, in <module>
    sys.exit(main())
    File "/opt/homebrew/lib/python3.10/site-packages/invoice2data/main.py", line 231, in main
    output_module.write_to_file(output, args.output_name, args.output_date_format)
    File "/opt/homebrew/lib/python3.10/site-packages/invoice2data/output/to_json.py", line 46, in write_to_file
    line[k] = v.strftime(date_format)
AttributeError: 'list' object has no attribute 'strftime'
```