### PR TITLE
templates: drop unused coding info from all templates

### DIFF
--- a/src/invoice2data/extract/templates/ch/ch.pcengines.yml
+++ b/src/invoice2data/extract/templates/ch/ch.pcengines.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: PC Engines GmbH
 fields:
   amount: Total\s+EUR\s+([\d,]+.\d{2})

--- a/src/invoice2data/extract/templates/com/com.amazon.aws.yml
+++ b/src/invoice2data/extract/templates/com/com.amazon.aws.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: Amazon Web Services
 fields:
   amount: TOTAL AMOUNT DUE ON.*\$(\d+\.\d+)

--- a/src/invoice2data/extract/templates/com/com.apple.yml
+++ b/src/invoice2data/extract/templates/com/com.apple.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: Apple Distribution International
 fields:
   amount: Total\s+Price\s+\(\w+.VAT\)\s+EUR\s+(\d+,\d{2})

--- a/src/invoice2data/extract/templates/com/com.binarylife.yml
+++ b/src/invoice2data/extract/templates/com/com.binarylife.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: BinaryLife Inc.
 fields:
   amount: Total\s?:\s+\$(\d+\.\d{2})

--- a/src/invoice2data/extract/templates/com/com.bloomberg.yml
+++ b/src/invoice2data/extract/templates/com/com.bloomberg.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: Bloomberg
 fields:
   amount: TOTAL \(USD \)\s+([\d,]+\.\d{2})

--- a/src/invoice2data/extract/templates/com/com.datadoghq.yml
+++ b/src/invoice2data/extract/templates/com/com.datadoghq.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # The Datadog invoices are really not nice!
 # So this invoice template is pretty weak. I hope Datadog will improve their
 # invoices in the future...

--- a/src/invoice2data/extract/templates/com/com.expressvpn.yml
+++ b/src/invoice2data/extract/templates/com/com.expressvpn.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: ExpressVPN
 fields:
   amount: Grand Total:\s+\$([\d,]+.\d{2})

--- a/src/invoice2data/extract/templates/com/com.ftserussell.yml
+++ b/src/invoice2data/extract/templates/com/com.ftserussell.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: FTSE Russel
 fields:
   amount_untaxed: Net Total\s+EUR\s+€([\d,]+\.\d{2})

--- a/src/invoice2data/extract/templates/com/com.linode.yml
+++ b/src/invoice2data/extract/templates/com/com.linode.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: Linode
 fields:
   amount: Invoice\s+Total:\$(\d+.\d{2})

--- a/src/invoice2data/extract/templates/com/com.mongodb.yml
+++ b/src/invoice2data/extract/templates/com/com.mongodb.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: mongoDB Cloud
 fields:
   amount: PAID\s+\w+\s\d{1,2},\s\d{4}\s+\$[\d,]+\.\d{2}\s+\$[\d,]+\.\d{2}\s+\$[\d,]+\.\d{2}\s+\$([\d,]+\.\d{2})

--- a/src/invoice2data/extract/templates/com/com.nyse.yml
+++ b/src/invoice2data/extract/templates/com/com.nyse.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: NYSE Market (DE) Inc.
 fields:
   amount: Invoice\s+Amount:\s+\$([\d,]+\.\d{2})

--- a/src/invoice2data/extract/templates/com/com.packtpub.yml
+++ b/src/invoice2data/extract/templates/com/com.packtpub.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: Packt Publishing
 fields:
   amount: Total\s+\d+\s+€(\d+.\d{2})

--- a/src/invoice2data/extract/templates/com/com.pixartprinting.yml
+++ b/src/invoice2data/extract/templates/com/com.pixartprinting.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: Pixartprinting SpA
 fields:
   amount: \d+\.\d+\s+[\d,]+\.\d{2}\s+[\d,]+\.\d{2}\s+[\d,]+\.\d{2}\s+[\d,]+\.\d{2}\s+[\d,]+\.\d{2}\s+[\d,]+\.\d{2}\s+([\d,]+\.\d{2})

--- a/src/invoice2data/extract/templates/com/com.tmx.yml
+++ b/src/invoice2data/extract/templates/com/com.tmx.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: TSX Inc.
 fields:
   amount: Total\s+Amount\s+Due\s+USD\s+\$([\d,]+\.\d{2})

--- a/src/invoice2data/extract/templates/de/de.amazon.yml
+++ b/src/invoice2data/extract/templates/de/de.amazon.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # TODO: this template needs more keyword in order to avoid matching
 # instead of other Amazon templates for other countries and/or languages
 fields:

--- a/src/invoice2data/extract/templates/es/com.pepephone.yml
+++ b/src/invoice2data/extract/templates/es/com.pepephone.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: PepePhone (Mobile & Internet)
 fields:
   amount: Total\sfactura\s+(\d+,\d{2})

--- a/src/invoice2data/extract/templates/es/es.supplies24.yml
+++ b/src/invoice2data/extract/templates/es/es.supplies24.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: supplies24.es
 fields:
   amount: Importe total:\s+(\d+,\d{2})

--- a/src/invoice2data/extract/templates/fr/co.mooncard.yml
+++ b/src/invoice2data/extract/templates/fr/co.mooncard.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: MoonGroup (mooncard.co)
 fields:
   amount: Total\s+à\s+payer\s+(\d+,\d{2})\s+€

--- a/src/invoice2data/extract/templates/fr/com.adobe.ie.yml
+++ b/src/invoice2data/extract/templates/fr/com.adobe.ie.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: Adobe Systems Software
 fields:
   amount: Montant\s+TTC\s+(\d+.\d{2})

--- a/src/invoice2data/extract/templates/fr/com.akretion.fr.yml
+++ b/src/invoice2data/extract/templates/fr/com.akretion.fr.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: Akretion France
 fields:
   amount: Total TTC :\s+(\d+,\d{2})

--- a/src/invoice2data/extract/templates/fr/com.amazon.aws.yml
+++ b/src/invoice2data/extract/templates/fr/com.amazon.aws.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: Amazon Web Services EMEA SARL, succursale française
 fields:
   amount: TOTAL\s+AMOUNT\s+EUR\s+(\d+.\d{2})

--- a/src/invoice2data/extract/templates/fr/com.ateliercopieservice.yml
+++ b/src/invoice2data/extract/templates/fr/com.ateliercopieservice.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: Atelier Copy Service
 fields:
   amount: Total TTC\s+([\d ]+.\d{2})

--- a/src/invoice2data/extract/templates/fr/com.chauffeur-prive.yml
+++ b/src/invoice2data/extract/templates/fr/com.chauffeur-prive.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: Chauffeur Privé (TRANSOPCO France SAS)
 fields:
   amount: Totalfacturé([\d ]+,\d{2})

--- a/src/invoice2data/extract/templates/fr/com.coriolis.yml
+++ b/src/invoice2data/extract/templates/fr/com.coriolis.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Designed to work on the 2 invoice models: mobile phone and Internet
 issuer: Coriolis Telecom
 fields:

--- a/src/invoice2data/extract/templates/fr/com.easyjet.fr.yml
+++ b/src/invoice2data/extract/templates/fr/com.easyjet.fr.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: Easyjet
 fields:
   amount: MONTANT TOTAL\s+([\d ]+,\d{2})

--- a/src/invoice2data/extract/templates/fr/com.eaudugrandlyon.yml
+++ b/src/invoice2data/extract/templates/fr/com.eaudugrandlyon.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: Eau du grand Lyon (eaudugrandlyon.com)
 fields:
   amount: Total\s+général\s+:\s+\d+,\d{2}\s+€\s+HT\s+\d+,\d{2}\s+(\d+,\d{2})

--- a/src/invoice2data/extract/templates/fr/com.godaddy.yml
+++ b/src/invoice2data/extract/templates/fr/com.godaddy.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: Go Daddy
 fields:
   amount: Total\s?:\s+(\d+,\d{2})

--- a/src/invoice2data/extract/templates/fr/com.google.ie.yml
+++ b/src/invoice2data/extract/templates/fr/com.google.ie.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: Google Ireland Limited
 fields:
   amount: Montant dû en EUR\s+:\s+([\d ]+,\d{2})

--- a/src/invoice2data/extract/templates/fr/com.hootsuite.yml
+++ b/src/invoice2data/extract/templates/fr/com.hootsuite.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: Hootsuite Media Inc.
 fields:
   amount: Montant payé\s?:\s+€(\d+,\d{2})

--- a/src/invoice2data/extract/templates/fr/com.jeanbesson.yml
+++ b/src/invoice2data/extract/templates/fr/com.jeanbesson.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: Transports Jean Besson
 fields:
   amount: MONTANT\s+TTC\s+A\s+REGLER\s+EN\s+EUROS\s+(\d+.\d{2})

--- a/src/invoice2data/extract/templates/fr/com.ldlc.yml
+++ b/src/invoice2data/extract/templates/fr/com.ldlc.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: LDLC.com
 fields:
   amount: Montant TTC\s+(\d+,\d{2})

--- a/src/invoice2data/extract/templates/fr/com.linkedin.yml
+++ b/src/invoice2data/extract/templates/fr/com.linkedin.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: LinkedIn Ireland Unlimited
 fields:
   amount: Facture\s*:\s+([\d\s]+,\d{2})

--- a/src/invoice2data/extract/templates/fr/com.mention.yml
+++ b/src/invoice2data/extract/templates/fr/com.mention.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: Mention Solutions SAS
 fields:
   amount: Total\s\(incl\.\sVAT\)\s+(\d+,\d{2})

--- a/src/invoice2data/extract/templates/fr/com.microsoft.ie.yml
+++ b/src/invoice2data/extract/templates/fr/com.microsoft.ie.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: Microsoft Ireland Operations Ltd
 fields:
   amount: Total\sdes\sfrais\sactuels\s+(\d+,\d{2})

--- a/src/invoice2data/extract/templates/fr/com.myflyingbox.yml
+++ b/src/invoice2data/extract/templates/fr/com.myflyingbox.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: My Flying Box
 fields:
   amount: \d+,\d{2}\s+€\s+\d+,\d{2}\s+€\s+(\d+,\d{2})\s+€

--- a/src/invoice2data/extract/templates/fr/com.officetimeline.yml
+++ b/src/invoice2data/extract/templates/fr/com.officetimeline.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: Office TIMELINE
 fields:
   amount: Total\spayé\s\(\w{3}\)\s+\$(\d+)

--- a/src/invoice2data/extract/templates/fr/com.orange-business.mobile.yml
+++ b/src/invoice2data/extract/templates/fr/com.orange-business.mobile.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: Orange Business Services
 fields:
   amount: somme\sà\spayer\s\(EUR\sTTC\)\s+(\d+,\d{2})

--- a/src/invoice2data/extract/templates/fr/com.ovh.fr.yml
+++ b/src/invoice2data/extract/templates/fr/com.ovh.fr.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: OVH.com
 fields:
   amount: TOTAL\s+TTC\s+([\d ]+,\d{2})

--- a/src/invoice2data/extract/templates/fr/com.rs-online.fr.yml
+++ b/src/invoice2data/extract/templates/fr/com.rs-online.fr.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: RadioSpares
 fields:
   amount: TOTAL TTC - EUR\s+([\d ]+,\d{2})

--- a/src/invoice2data/extract/templates/fr/com.saur.yml
+++ b/src/invoice2data/extract/templates/fr/com.saur.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Doesn't work with the new version of pdftotext : Copying of text from this document is not allowed.
 issuer: Saur
 fields:

--- a/src/invoice2data/extract/templates/fr/com.soyoustart.yml
+++ b/src/invoice2data/extract/templates/fr/com.soyoustart.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: So you Start (OVH)
 fields:
   amount: TOTAL\s+TTC\s+(\d+.\d{2})

--- a/src/invoice2data/extract/templates/fr/com.vinci-autoroutes.yml
+++ b/src/invoice2data/extract/templates/fr/com.vinci-autoroutes.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: Vinci Autoroutes
 fields:
   amount: NET A PAYER TTC\s+(\d+,\d{2})

--- a/src/invoice2data/extract/templates/fr/dolibarr.generique.yml
+++ b/src/invoice2data/extract/templates/fr/dolibarr.generique.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: Facture dolibarr generique (1)
 fields:
   invoice_number: '.*R.f.\s+:\s+(.*)'

--- a/src/invoice2data/extract/templates/fr/eu.trainline.yml
+++ b/src/invoice2data/extract/templates/fr/eu.trainline.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: Trainline.eu
 fields:
   amount: Montant\s+total\s+:\s+€(\d+.\d{2})

--- a/src/invoice2data/extract/templates/fr/fr.actn.yml
+++ b/src/invoice2data/extract/templates/fr/fr.actn.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: ACTN
 fields:
   date: Date\s+facture\s+:\s+(\d+/\d+/+\d{4})

--- a/src/invoice2data/extract/templates/fr/fr.airfrance.yml
+++ b/src/invoice2data/extract/templates/fr/fr.airfrance.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: Air France
 fields:
   amount: NET A PAYER\s+([\d ]+.\d{2})

--- a/src/invoice2data/extract/templates/fr/fr.also.yml
+++ b/src/invoice2data/extract/templates/fr/fr.also.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: ALSO France
 fields:
   date: Date\s+(\d+.\d+.+\d{4})

--- a/src/invoice2data/extract/templates/fr/fr.amazon.yml
+++ b/src/invoice2data/extract/templates/fr/fr.amazon.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: Amazon France
 fields:
   amount: Facture Total\s+([\d ]+,\d{2})

--- a/src/invoice2data/extract/templates/fr/fr.assurance-epargne-pension.yml
+++ b/src/invoice2data/extract/templates/fr/fr.assurance-epargne-pension.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: AEP - ASSURANCE EPARGNE PENSION
 fields:
   amount: Soit un net à payer de :\s+([\d\s]+,\d{2})

--- a/src/invoice2data/extract/templates/fr/fr.bouyguestelecom.adsl-fiber.yml
+++ b/src/invoice2data/extract/templates/fr/fr.bouyguestelecom.adsl-fiber.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: Bouygues Telecom (ADSL/Fibre)
 fields:
   amount: Montant total de cette facture\s+(\d+.\d{2})

--- a/src/invoice2data/extract/templates/fr/fr.bouyguestelecom.mobile.yml
+++ b/src/invoice2data/extract/templates/fr/fr.bouyguestelecom.mobile.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: Bouygues Telecom (Mobile)
 fields:
   amount: Montant de la facture soumis à TVA\s+\d+,\d{2}\s+(\d+,\d{2})

--- a/src/invoice2data/extract/templates/fr/fr.butagaz.yml
+++ b/src/invoice2data/extract/templates/fr/fr.butagaz.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: Gaz de Paris
 keywords:
 - Butagaz

--- a/src/invoice2data/extract/templates/fr/fr.chronopost.yml
+++ b/src/invoice2data/extract/templates/fr/fr.chronopost.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: Chronopost
 fields:
   amount: TOTAL FACTURE\s+\d+.\d{2}\s+\d+.\d{2}\s+(\d+.\d{2})

--- a/src/invoice2data/extract/templates/fr/fr.dirafi.yml
+++ b/src/invoice2data/extract/templates/fr/fr.dirafi.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: dirafi.fr
 fields:
   amount: Total TTC\s+([\d\s]+,\d{2})

--- a/src/invoice2data/extract/templates/fr/fr.domaine-achat.yml
+++ b/src/invoice2data/extract/templates/fr/fr.domaine-achat.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: PRIVIANET SARL
 fields:
   amount: Total TTC\s+(\d+.\d{2})

--- a/src/invoice2data/extract/templates/fr/fr.easytrip.yml
+++ b/src/invoice2data/extract/templates/fr/fr.easytrip.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: Easytrip France
 fields:
   amount: TOTAL\s+A\s+PAYER\s+[\d ]+,\d{2}\s+[\d ]+,\d{2}\s+([\d ]+,\d{2})

--- a/src/invoice2data/extract/templates/fr/fr.edf.entreprises.yml
+++ b/src/invoice2data/extract/templates/fr/fr.edf.entreprises.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: EDF
 fields:
   amount: Total TTC en euros \(détails au verso\) :\s+([\d ]+,\d{2})

--- a/src/invoice2data/extract/templates/fr/fr.edf.pme.yml
+++ b/src/invoice2data/extract/templates/fr/fr.edf.pme.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: EDF
 fields:
   amount: Facture TTC\s+([\d ]+,\d{2})

--- a/src/invoice2data/extract/templates/fr/fr.finagaz.yml
+++ b/src/invoice2data/extract/templates/fr/fr.finagaz.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: FINAGAZ
 fields:
   amount: Montant TTC en notre faveur\s+([\d ]+,\d{2})

--- a/src/invoice2data/extract/templates/fr/fr.fountain.yml
+++ b/src/invoice2data/extract/templates/fr/fr.fountain.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: fountain.fr
 fields:
   amount: Montant total\s+([\d ]+,\d{2})

--- a/src/invoice2data/extract/templates/fr/fr.free.adsl-fiber.yml
+++ b/src/invoice2data/extract/templates/fr/fr.free.adsl-fiber.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: Free
 fields:
   amount: Total facture\s+\d+.\d{2}\s+\d+.\d{2}\s+(\d+.\d{2})

--- a/src/invoice2data/extract/templates/fr/fr.free.mobile.yml
+++ b/src/invoice2data/extract/templates/fr/fr.free.mobile.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: Free Mobile
 fields:
   amount: \spayer TTC\*\s+(\d+.\d{2})

--- a/src/invoice2data/extract/templates/fr/fr.free.mobile2.yml
+++ b/src/invoice2data/extract/templates/fr/fr.free.mobile2.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: Free Mobile
 fields:
   amount: \spayer TTC\*\s+(\d+.\d{2})

--- a/src/invoice2data/extract/templates/fr/fr.futur.yml
+++ b/src/invoice2data/extract/templates/fr/fr.futur.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: Futur Telecom SAS
 fields:
   amount: Total T.T.C.\s+\(€\)\s+(\d+,\d{2})

--- a/src/invoice2data/extract/templates/fr/fr.ge-iroise.yml
+++ b/src/invoice2data/extract/templates/fr/fr.ge-iroise.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: GE IROISE
 fields:
   amount: Total\s+T.T.C.\s+([\d\s]+,\d{2})

--- a/src/invoice2data/extract/templates/fr/fr.greffe-tc-lyon.yml
+++ b/src/invoice2data/extract/templates/fr/fr.greffe-tc-lyon.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: Greffe du tribunal de commerce de Lyon
 fields:
   amount: TOTAL\s+TTC\s?:\s+(\d+,\d{2})

--- a/src/invoice2data/extract/templates/fr/fr.hiscox.yml
+++ b/src/invoice2data/extract/templates/fr/fr.hiscox.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: Hiscox Europe
 fields:
   amount: Prime TTC\s+([\d ]+,\d{2})

--- a/src/invoice2data/extract/templates/fr/fr.internetsatellite.yml
+++ b/src/invoice2data/extract/templates/fr/fr.internetsatellite.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: Sat2Way
 fields:
   amount: Total\s+:\s+(\d+.\d{2})

--- a/src/invoice2data/extract/templates/fr/fr.jpg.yml
+++ b/src/invoice2data/extract/templates/fr/fr.jpg.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: JPG
 fields:
   amount: \d+,\d{2}\s+\d+,\d{2}\s+\d+,\d{2}\s+\d+,\d{2}\s+(\d+,\d{2})

--- a/src/invoice2data/extract/templates/fr/fr.kubii.yml
+++ b/src/invoice2data/extract/templates/fr/fr.kubii.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: KUBII
 fields:
   amount: \sTotal\s+(\d+,\d{2})\s€

--- a/src/invoice2data/extract/templates/fr/fr.laposte.boutique.yml
+++ b/src/invoice2data/extract/templates/fr/fr.laposte.boutique.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: La Poste (Coliposte et Solutions Business)
 fields:
   amount: Montant\s+à\s+payer\s+en\s+Euros\s+(\d+,\d{2})

--- a/src/invoice2data/extract/templates/fr/fr.laposte.coliposte.yml
+++ b/src/invoice2data/extract/templates/fr/fr.laposte.coliposte.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: La Poste (Coliposte)
 fields:
   amount: Total TTC:\s+(\d+,\d{2})

--- a/src/invoice2data/extract/templates/fr/fr.lecab.yml
+++ b/src/invoice2data/extract/templates/fr/fr.lecab.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: leCab
 fields:
   amount: Montant\s+total\s+à\s+régler\s+([\d\s]+,\d{2})

--- a/src/invoice2data/extract/templates/fr/fr.leroymerlin.yml
+++ b/src/invoice2data/extract/templates/fr/fr.leroymerlin.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: Leroy Merlin France
 fields:
   amount: Total TTC\s+(\d+.\d{2})

--- a/src/invoice2data/extract/templates/fr/fr.maaf.yml
+++ b/src/invoice2data/extract/templates/fr/fr.maaf.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: MAAF Assurances SA
 fields:
   amount: VOTRE\sCOTISATION\sANNUELLE\s+\d{4}\s+(\d+,\d{2})

--- a/src/invoice2data/extract/templates/fr/fr.mediapart.yml
+++ b/src/invoice2data/extract/templates/fr/fr.mediapart.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: Mediapart
 fields:
   amount: TOTAL\sTTC\s+(\d+.\d{2})

--- a/src/invoice2data/extract/templates/fr/fr.moneo-resto.yml
+++ b/src/invoice2data/extract/templates/fr/fr.moneo-resto.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: Moneo Resto
 fields:
   amount: Total\sTTC\s+(\d+,\d{2})

--- a/src/invoice2data/extract/templates/fr/fr.mouser.yml
+++ b/src/invoice2data/extract/templates/fr/fr.mouser.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # The PDF invoice has the 2 languages: French and English
 issuer: Mouser Electronic
 fields:

--- a/src/invoice2data/extract/templates/fr/fr.mycelium-roulement.yml
+++ b/src/invoice2data/extract/templates/fr/fr.mycelium-roulement.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: Mycelium Roulement - 123roulement
 fields:
   amount: Total\sT\.T\.C\.\s+(\d+,\d{2})\s+EUR

--- a/src/invoice2data/extract/templates/fr/fr.napsis.yml
+++ b/src/invoice2data/extract/templates/fr/fr.napsis.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: Napsis (Iperlink)
 fields:
   amount: TOTAL TTC À PAYER\s+(\d+,\d{2})

--- a/src/invoice2data/extract/templates/fr/fr.nexity.yml
+++ b/src/invoice2data/extract/templates/fr/fr.nexity.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: Nexity
 fields:
   amount: SOLDE\sÀ\sPAYER\s+\(en\s€\)\s+([\d ]+,\d{2})

--- a/src/invoice2data/extract/templates/fr/fr.orange.fibre.yml
+++ b/src/invoice2data/extract/templates/fr/fr.orange.fibre.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: Orange (Fibre optique)
 fields:
   amount: total auprès d\'Orange\s+\d+,\d{2}\s+(\d+,\d{2})

--- a/src/invoice2data/extract/templates/fr/fr.orange.fixedline.yml
+++ b/src/invoice2data/extract/templates/fr/fr.orange.fixedline.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: Orange (Fixed line)
 fields:
   amount: total des abonnements et achats\s+\d+,\d{2}\s+(\d+,\d{2})

--- a/src/invoice2data/extract/templates/fr/fr.prestaclic.yml
+++ b/src/invoice2data/extract/templates/fr/fr.prestaclic.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: Prestaclic
 fields:
   amount: TOTAL\s+TTC\s+([\d ]+,\d{2})

--- a/src/invoice2data/extract/templates/fr/fr.publicationannoncelegale.yml
+++ b/src/invoice2data/extract/templates/fr/fr.publicationannoncelegale.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: NETPRESSE
 fields:
   amount: Total TTC\s+:\s+([\d ]+,\d{2})

--- a/src/invoice2data/extract/templates/fr/fr.sfr.adsl-fiber.yml
+++ b/src/invoice2data/extract/templates/fr/fr.sfr.adsl-fiber.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: SFR
 fields:
   amount: TOTAL\s+prestations\s+facturées\s.+\d+,\d{2}\s+\d+,\d{2}\s+(\d+,\d{2})

--- a/src/invoice2data/extract/templates/fr/fr.sfr.mobile.yml
+++ b/src/invoice2data/extract/templates/fr/fr.sfr.mobile.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: SFR
 fields:
   amount: (\d+,\d{2}) € TTC

--- a/src/invoice2data/extract/templates/fr/fr.sosh.yml
+++ b/src/invoice2data/extract/templates/fr/fr.sosh.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: Sosh by Orange
 fields:
   amount: total auprès d\'Orange\s+\d+,\d{2}\s+(\d+,\d{2})

--- a/src/invoice2data/extract/templates/fr/fr.teledec.yml
+++ b/src/invoice2data/extract/templates/fr/fr.teledec.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: Teledec.fr - LPI Conseil SAS
 fields:
   amount: Total\s+TTC\s+:\s+(\d+,\d{2})

--- a/src/invoice2data/extract/templates/fr/fr.topoffice.yml
+++ b/src/invoice2data/extract/templates/fr/fr.topoffice.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: Top Office
 fields:
   amount: '.*TOTAL\sTTC\s+(\d+.\d{2})\sEUR'

--- a/src/invoice2data/extract/templates/fr/net.online.yml
+++ b/src/invoice2data/extract/templates/fr/net.online.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: Online SAS
 fields:
   amount: '[\d ]+,\d{2}\s+Euros\s+\d+,\d{2}\s\%\s+[\d ]+,\d{2}\s+Euros\s+([\d ]+,\d{2})\sEuros'

--- a/src/invoice2data/extract/templates/fr/net.scaleway.yml
+++ b/src/invoice2data/extract/templates/fr/net.scaleway.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: Online SAS / Scaleway
 fields:
   amount: '.*Total\s+due\s+€(\d+.\d{2})'

--- a/src/invoice2data/extract/templates/nl/nl.action.yml
+++ b/src/invoice2data/extract/templates/nl/nl.action.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: MIT
 issuer: action
 fields:

--- a/src/invoice2data/extract/templates/nl/nl.albron.yml
+++ b/src/invoice2data/extract/templates/nl/nl.albron.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: MIT
 issuer: Albron
 fields:

--- a/src/invoice2data/extract/templates/nl/nl.begra.yml
+++ b/src/invoice2data/extract/templates/nl/nl.begra.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: MIT
 issuer: Begra Magazijninrichting B.V.
 fields:

--- a/src/invoice2data/extract/templates/nl/nl.blokker.yml
+++ b/src/invoice2data/extract/templates/nl/nl.blokker.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: MIT
 issuer: blokker
 fields:

--- a/src/invoice2data/extract/templates/nl/nl.bunq.yml
+++ b/src/invoice2data/extract/templates/nl/nl.bunq.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: MIT
 issuer: bunq
 fields:

--- a/src/invoice2data/extract/templates/nl/nl.cpe.yml
+++ b/src/invoice2data/extract/templates/nl/nl.cpe.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: CPE B.V.
 fields:
   amount: Te\s+betalen\s+in\s+EUR:\s+(\d+,\d{2})

--- a/src/invoice2data/extract/templates/nl/nl.farnell.yml
+++ b/src/invoice2data/extract/templates/nl/nl.farnell.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: MIT
 issuer: Farnell (Netherlands) B.V.
 fields:

--- a/src/invoice2data/extract/templates/nl/nl.ferbox.yml
+++ b/src/invoice2data/extract/templates/nl/nl.ferbox.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: MIT
 issuer: FERBOX
 fields:

--- a/src/invoice2data/extract/templates/nl/nl.gamma.yml
+++ b/src/invoice2data/extract/templates/nl/nl.gamma.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: MIT
 issuer: Gamma
 fields:

--- a/src/invoice2data/extract/templates/nl/nl.goos.yml
+++ b/src/invoice2data/extract/templates/nl/nl.goos.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: MIT
 issuer: Goos van Pelt B.V.
 fields:

--- a/src/invoice2data/extract/templates/nl/nl.karwei.yml
+++ b/src/invoice2data/extract/templates/nl/nl.karwei.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: MIT
 issuer: Karwei
 fields:

--- a/src/invoice2data/extract/templates/nl/nl.kav.yml
+++ b/src/invoice2data/extract/templates/nl/nl.kav.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: kavautoverhuur
 fields:
   amount: Totaal\s+[€]\s+-?(\d+.\d{2})

--- a/src/invoice2data/extract/templates/nl/nl.koffiehenk.yml
+++ b/src/invoice2data/extract/templates/nl/nl.koffiehenk.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: MIT
 issuer: KoffieHenk
 fields:

--- a/src/invoice2data/extract/templates/nl/nl.praxis.yml
+++ b/src/invoice2data/extract/templates/nl/nl.praxis.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: MIT
 issuer: Praxis
 fields:

--- a/src/invoice2data/extract/templates/nl/nl.reclameland.yml
+++ b/src/invoice2data/extract/templates/nl/nl.reclameland.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: MIT
 issuer: Reclameland BV
 fields:

--- a/src/invoice2data/extract/templates/nl/nl.simpel.yml
+++ b/src/invoice2data/extract/templates/nl/nl.simpel.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: MIT
 issuer: Simpel
 fields:

--- a/src/invoice2data/extract/templates/nl/nl.transip.yml
+++ b/src/invoice2data/extract/templates/nl/nl.transip.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: MIT
 issuer: Transip
 fields:

--- a/src/invoice2data/extract/templates/nl/nl.tuynder.yml
+++ b/src/invoice2data/extract/templates/nl/nl.tuynder.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: MIT
 issuer: Tuynder B.V.
 fields:

--- a/src/invoice2data/extract/templates/nl/nl.vistaprint.yml
+++ b/src/invoice2data/extract/templates/nl/nl.vistaprint.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: Vistaprint
 fields:
   amount: '.*Total\s+(\d+,\d{2})\s+'

--- a/src/invoice2data/extract/templates/nl/nl.vodafone.yml
+++ b/src/invoice2data/extract/templates/nl/nl.vodafone.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: MIT
 issuer: Vodafone Libertel B.V.
 fields:

--- a/src/invoice2data/extract/templates/nl/nl.wasco.yml
+++ b/src/invoice2data/extract/templates/nl/nl.wasco.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: Wasco Groothandelsgroep B.V.
 fields:
   amount: Factuurbedrag\s+EUR\s+\(Incl\.\s+BTW\)\s+(\d+,\d{2})

--- a/src/invoice2data/extract/templates/nl/nl.weid.yml
+++ b/src/invoice2data/extract/templates/nl/nl.weid.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: MIT
 issuer: connected information systems B.V.
 fields:

--- a/src/invoice2data/extract/templates/nl/nl.yezzer.yml
+++ b/src/invoice2data/extract/templates/nl/nl.yezzer.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: MIT
 issuer: Yezzer
 fields:

--- a/src/invoice2data/extract/templates/nl/nl.zinkunie.yml
+++ b/src/invoice2data/extract/templates/nl/nl.zinkunie.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 issuer: Zinkunie B.V.
 fields:
   amount: Totaal\s+EURO\s+:\s+(\d+,\d{2})

--- a/src/invoice2data/extract/templates/pl/pl.bmw-fs.yml
+++ b/src/invoice2data/extract/templates/pl/pl.bmw-fs.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: MIT
 issuer: BMW Financial Services Polska spółka z ograniczoną odpowiedzialnością
 keywords:

--- a/src/invoice2data/extract/templates/pl/pl.orlen.yml
+++ b/src/invoice2data/extract/templates/pl/pl.orlen.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: MIT
 issuer: Polski Koncern Naftowy ORLEN spółka akcyjna
 keywords:

--- a/src/invoice2data/extract/templates/pl/pl.p4.yml
+++ b/src/invoice2data/extract/templates/pl/pl.p4.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: MIT
 issuer: P4 spółka z ograniczoną odpowiedzialnością
 keywords:

--- a/src/invoice2data/extract/templates/pl/pl.paypro.yml
+++ b/src/invoice2data/extract/templates/pl/pl.paypro.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: MIT
 issuer: PayPro spółka akcyjna
 keywords:


### PR DESCRIPTION
```
For some unkown reason early templates contained line like:
    # -*- coding: utf-8 -*-

It seems to be unused. It doesn't belong to YAML specification. It seems
like a copy & paste mistake from Python source file.

Remove all those unused lines. All YAML templates as expected to be
UTF-8 encoded anyway.

Those changes were automatically generated using:
sed -i '/coding:/d' src/invoice2data/extract/templates/*/*.yml
find ./tests/custom/ -name "*.yml" -exec sed -i '/coding:/d' {} \;
```