### PR TITLE
output: to_csv: print header for every set of parsed fields

### DIFF
--- a/src/invoice2data/output/to_csv.py
+++ b/src/invoice2data/output/to_csv.py
@@ -41,13 +41,16 @@ def write_to_file(data: list, path: str, date_format="%Y-%m-%d") -> None:
     with openfile as csv_file:
         writer = csv.writer(csv_file, delimiter=",")
 
+        last_header = None
         for line in data:
             first_row = []
             for k, v in line.items():
                 first_row.append(k)
 
-        writer.writerow(first_row)
-        for line in data:
+            if first_row != last_header:
+                writer.writerow(first_row)
+            last_header = first_row
+
             csv_items = []
             for k, v in line.items():
                 # first_row.append(k)


### PR DESCRIPTION
```
When parsing multiple invoices it's *incorrect* to:
1. Display header with fields names of the *first* parsed invoice
2. Display content of *all* parsed invoices

It's because parsing dfferent invoices may result in different fields.
In such case header won't make sense for all rows.

To improve handling such situations display new header for every set of
fields that differs from the last one.
```