### PR TITLE
Don't set empty fields in output

### DIFF
--- a/src/invoice2data/extract/invoice_template.py
+++ b/src/invoice2data/extract/invoice_template.py
@@ -214,7 +214,7 @@ class InvoiceTemplate(OrderedDict):
                     if v["parser"] in PARSERS_MAPPING:
                         parser = PARSERS_MAPPING[v["parser"]]
                         value = parser.parse(self, k, v, optimized_str_for_parser)
-                        if value is not None:
+                        if value:
                             output[k] = value
                         else:
                             logger.error("Failed to parse field %s with parser %s", k, v["parser"])
@@ -239,7 +239,7 @@ class InvoiceTemplate(OrderedDict):
                 else:
                     result = parsers.regex.parse(self, k, {"regex": v}, optimized_str, True)
 
-                if result is None:
+                if not result:
                     logger.warning("regexp for field %s didn't match", k)
                 else:
                     output[k] = result


### PR DESCRIPTION
```
Before introducing parsers concept extract() did not set empty fields in
output. So in case of re.findall() returning an empty list there was a
warning like:
WARNING:invoice2data.extract.invoice_template:regexp for field <foo> didn't match
and on <foo> in output dictionary / file.

That has unintentionally changed after commit 670f8729b7b6 ("Extend
fields syntax to support associative arrays & add 2 initial parsers
(#308)"). Output can now look like:
[
    {
        "issuer": "Company",
        "amount": 12.34,
        "date": "2023-01-01",
        "invoice_number": "01/2023",
        "test_field": [],
        "currency": "EUR",
        "desc": "Invoice from Company"
    }
]

Bring back old behaviour and don't set empty fields:
[
    {
        "issuer": "Company",
        "amount": 12.34,
        "date": "2023-01-01",
        "invoice_number": "01/2023",
        "currency": "EUR",
        "desc": "Invoice from Company"
    }
]
```