### PR TITLE
Refactor and test template loader mechanism

### DIFF
--- a/src/invoice2data/extract/loader.py
+++ b/src/invoice2data/extract/loader.py
@@ -1,7 +1,7 @@
 import codecs
 import logging
-import os
 from collections import OrderedDict
+from pathlib import Path
 
 import pkg_resources
 import yaml
@@ -27,7 +27,7 @@ def ordered_load(stream):
     return yaml.load(stream, OrderedLoader)
 
 
-def read_templates(folder=None):
+def read_templates(folder: str = None):
     """
     Load yaml templates from template folder. Use built-in templates if no folder is set.
 
@@ -45,39 +45,35 @@ def read_templates(folder=None):
     if folder is None:
         folder = pkg_resources.resource_filename(__name__, "templates")
 
-    for path, _, files in os.walk(folder):
-        for name in sorted(files):
-            if name.endswith(".yml") is False:
+    templatedirectory: Path = Path(folder)
+
+    for yamlfile in sorted(templatedirectory.glob("**/*.yml")):
+        with codecs.open(str(yamlfile), encoding="utf-8") as templatefile:
+            try:
+                template = ordered_load(templatefile.read())
+            except yaml.parser.ParserError as error:
+                logger.warning(f"Failed to load {yamlfile.name} template:\n{error}")
                 continue
 
-            with codecs.open(
-                os.path.join(path, name), encoding="utf-8"
-            ) as template_file:
-                try:
-                    template = ordered_load(template_file.read())
-                except yaml.parser.ParserError as error:
-                    logger.warning(f"Failed to load {name} template:\n{error}")
-                    continue
+        template["template_name"] = yamlfile.name
 
-            template["template_name"] = name
+        # Test if all required fields are in template
+        if "keywords" not in template.keys():
+            raise ValueError("Missing mandatory 'keywords' field.")
 
-            # Test if all required fields are in template
-            if "keywords" not in template.keys():
-                raise ValueError("Missing mandatory 'keywords' field.")
+        # Convert keywords to list, if only one
+        if not isinstance(template["keywords"], list):
+            template["keywords"] = [template["keywords"]]
 
-            # Convert keywords to list, if only one
-            if not isinstance(template["keywords"], list):
-                template["keywords"] = [template["keywords"]]
+        # Set excluded_keywords as empty list, if not provided
+        if "exclude_keywords" not in template.keys():
+            template["exclude_keywords"] = []
 
-            # Set excluded_keywords as empty list, if not provided
-            if "exclude_keywords" not in template.keys():
-                template["exclude_keywords"] = []
+        # Convert excluded_keywords to list, if only one
+        if not isinstance(template["exclude_keywords"], list):
+            template["exclude_keywords"] = [template["exclude_keywords"]]
 
-            # Convert excluded_keywords to list, if only one
-            if not isinstance(template["exclude_keywords"], list):
-                template["exclude_keywords"] = [template["exclude_keywords"]]
-
-            invoicetemplates.append(InvoiceTemplate(template))
+        invoicetemplates.append(InvoiceTemplate(template))
 
     logger.info(f"Loaded {len(invoicetemplates)} templates from {folder}")
 

--- a/src/invoice2data/extract/loader.py
+++ b/src/invoice2data/extract/loader.py
@@ -1,10 +1,12 @@
-import os
-import yaml
-import pkg_resources
-from collections import OrderedDict
-import logging
-from .invoice_template import InvoiceTemplate
 import codecs
+import logging
+import os
+from collections import OrderedDict
+
+import pkg_resources
+import yaml
+
+from .invoice_template import InvoiceTemplate
 
 logger = logging.getLogger(__name__)
 

--- a/src/invoice2data/extract/loader.py
+++ b/src/invoice2data/extract/loader.py
@@ -1,9 +1,3 @@
-"""
-This module abstracts templates for invoice providers.
-
-Templates are initially read from .yml files and then kept as class.
-"""
-
 import os
 import yaml
 import pkg_resources
@@ -39,40 +33,15 @@ def ordered_load(stream, Loader=yaml.Loader, object_pairs_hook=OrderedDict):
 
 def read_templates(folder=None):
     """
-    Load yaml templates from template folder. Return list of dicts.
-
-    Use built-in templates if no folder is set.
+    Load yaml templates from template folder. Use built-in templates if no folder is set.
 
     Parameters
     ----------
     folder : str
-        user defined folder where they stores their files, if None uses built-in templates
 
     Returns
     -------
-    output : Instance of `InvoiceTemplate`
-        template which match based on keywords
-
-    Examples
-    --------
-
-    >>> read_template("home/duskybomb/invoice-templates/")
-    InvoiceTemplate([('issuer', 'OYO'), ('fields', OrderedDict([('amount', 'GrandTotalRs(\\d+)'),
-    ('date', 'Date:(\\d{1,2}\\/\\d{1,2}\\/\\d{1,4})'), ('invoice_number', '([A-Z0-9]+)CashatHotel')])),
-    ('keywords', ['OYO', 'Oravel', 'Stays']), ('options', OrderedDict([('currency', 'INR'), ('decimal_separator', '.'),
-    ('remove_whitespace', True)])), ('template_name', 'com.oyo.invoice.yml')])
-
-    After reading the template you can use the result as an instance of `InvoiceTemplate` to extract fields from
-    `extract_data()`
-
-    >>> my_template = InvoiceTemplate([('issuer', 'OYO'), ('fields', OrderedDict([('amount', 'GrandTotalRs(\\d+)'),
-    ('date', 'Date:(\\d{1,2}\\/\\d{1,2}\\/\\d{1,4})'), ('invoice_number', '([A-Z0-9]+)CashatHotel')])),
-    ('keywords', ['OYO', 'Oravel', 'Stays']), ('options', OrderedDict([('currency', 'INR'), ('decimal_separator', '.'),
-    ('remove_whitespace', True)])), ('template_name', 'com.oyo.invoice.yml')])
-    >>> extract_data("invoice2data/test/pdfs/oyo.pdf", my_template, pdftotext)
-    {'issuer': 'OYO', 'amount': 1939.0, 'date': datetime.datetime(2017, 12, 31, 0, 0), 'invoice_number': 'IBZY2087',
-     'currency': 'INR', 'desc': 'Invoice IBZY2087 from OYO'}
-
+    output : list of `InvoiceTemplate`
     """
 
     output = []

--- a/src/invoice2data/extract/loader.py
+++ b/src/invoice2data/extract/loader.py
@@ -37,43 +37,43 @@ def read_templates(folder=None):
 
     Returns
     -------
-    output : list of `InvoiceTemplate`
+    invoicetemplates : list of `InvoiceTemplate`
     """
 
-    output = []
+    invoicetemplates = []
 
     if folder is None:
         folder = pkg_resources.resource_filename(__name__, "templates")
 
-    for path, subdirs, files in os.walk(folder):
+    for path, _, files in os.walk(folder):
         for name in sorted(files):
             if name.endswith(".yml"):
                 with codecs.open(
                     os.path.join(path, name), encoding="utf-8"
                 ) as template_file:
                     try:
-                        tpl = ordered_load(template_file.read())
+                        template = ordered_load(template_file.read())
                     except yaml.parser.ParserError as error:
                         logger.warning("Failed to load %s template:\n%s", name, error)
                         continue
-                tpl["template_name"] = name
+                template["template_name"] = name
 
                 # Test if all required fields are in template:
-                assert "keywords" in tpl.keys(), "Missing keywords field."
+                assert "keywords" in template.keys(), "Missing keywords field."
 
                 # Keywords as list, if only one.
-                if type(tpl["keywords"]) is not list:
-                    tpl["keywords"] = [tpl["keywords"]]
+                if type(template["keywords"]) is not list:
+                    template["keywords"] = [template["keywords"]]
 
                 # Define excluded_keywords as empty list if not provided
                 # Convert to list if only one provided
-                if "exclude_keywords" not in tpl.keys():
-                    tpl["exclude_keywords"] = []
-                elif type(tpl["exclude_keywords"]) is not list:
-                    tpl["exclude_keywords"] = [tpl["exclude_keywords"]]
+                if "exclude_keywords" not in template.keys():
+                    template["exclude_keywords"] = []
+                elif type(template["exclude_keywords"]) is not list:
+                    template["exclude_keywords"] = [template["exclude_keywords"]]
 
-                output.append(InvoiceTemplate(tpl))
+                invoicetemplates.append(InvoiceTemplate(template))
 
-    logger.info("Loaded %d templates from %s", len(output), folder)
+    logger.info("Loaded %d templates from %s", len(invoicetemplates), folder)
 
-    return output
+    return invoicetemplates

--- a/src/invoice2data/extract/loader.py
+++ b/src/invoice2data/extract/loader.py
@@ -11,20 +11,14 @@ from .invoice_template import InvoiceTemplate
 logger = logging.getLogger(__name__)
 
 
-# borrowed from http://stackoverflow.com/a/21912744
-def ordered_load(stream, Loader=yaml.Loader, object_pairs_hook=OrderedDict):
-    """load mappings and ordered mappings
-
-    loader to load mappings and ordered mappings into the Python 2.7+ OrderedDict type,
-    instead of the vanilla dict and the list of pairs it currently uses.
-    """
-
-    class OrderedLoader(Loader):
+def ordered_load(stream):
+    # Simplified version of http://stackoverflow.com/a/21912744
+    class OrderedLoader(yaml.Loader):
         pass
 
     def construct_mapping(loader, node):
         loader.flatten_mapping(node)
-        return object_pairs_hook(loader.construct_pairs(node))
+        return OrderedDict(loader.construct_pairs(node))
 
     OrderedLoader.add_constructor(
         yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, construct_mapping

--- a/src/invoice2data/extract/loader.py
+++ b/src/invoice2data/extract/loader.py
@@ -61,18 +61,20 @@ def read_templates(folder=None):
 
             template["template_name"] = name
 
-            # Test if all required fields are in template:
-            assert "keywords" in template.keys(), "Missing keywords field."
+            # Test if all required fields are in template
+            if "keywords" not in template.keys():
+                raise ValueError("Missing mandatory 'keywords' field.")
 
-            # Keywords as list, if only one.
-            if type(template["keywords"]) is not list:
+            # Convert keywords to list, if only one
+            if not isinstance(template["keywords"], list):
                 template["keywords"] = [template["keywords"]]
 
-            # Define excluded_keywords as empty list if not provided
-            # Convert to list if only one provided
+            # Set excluded_keywords as empty list, if not provided
             if "exclude_keywords" not in template.keys():
                 template["exclude_keywords"] = []
-            elif type(template["exclude_keywords"]) is not list:
+
+            # Convert excluded_keywords to list, if only one
+            if not isinstance(template["exclude_keywords"], list):
                 template["exclude_keywords"] = [template["exclude_keywords"]]
 
             invoicetemplates.append(InvoiceTemplate(template))

--- a/src/invoice2data/extract/loader.py
+++ b/src/invoice2data/extract/loader.py
@@ -47,32 +47,35 @@ def read_templates(folder=None):
 
     for path, _, files in os.walk(folder):
         for name in sorted(files):
-            if name.endswith(".yml"):
-                with codecs.open(
-                    os.path.join(path, name), encoding="utf-8"
-                ) as template_file:
-                    try:
-                        template = ordered_load(template_file.read())
-                    except yaml.parser.ParserError as error:
-                        logger.warning("Failed to load %s template:\n%s", name, error)
-                        continue
-                template["template_name"] = name
+            if name.endswith(".yml") is False:
+                continue
 
-                # Test if all required fields are in template:
-                assert "keywords" in template.keys(), "Missing keywords field."
+            with codecs.open(
+                os.path.join(path, name), encoding="utf-8"
+            ) as template_file:
+                try:
+                    template = ordered_load(template_file.read())
+                except yaml.parser.ParserError as error:
+                    logger.warning("Failed to load %s template:\n%s", name, error)
+                    continue
 
-                # Keywords as list, if only one.
-                if type(template["keywords"]) is not list:
-                    template["keywords"] = [template["keywords"]]
+            template["template_name"] = name
 
-                # Define excluded_keywords as empty list if not provided
-                # Convert to list if only one provided
-                if "exclude_keywords" not in template.keys():
-                    template["exclude_keywords"] = []
-                elif type(template["exclude_keywords"]) is not list:
-                    template["exclude_keywords"] = [template["exclude_keywords"]]
+            # Test if all required fields are in template:
+            assert "keywords" in template.keys(), "Missing keywords field."
 
-                invoicetemplates.append(InvoiceTemplate(template))
+            # Keywords as list, if only one.
+            if type(template["keywords"]) is not list:
+                template["keywords"] = [template["keywords"]]
+
+            # Define excluded_keywords as empty list if not provided
+            # Convert to list if only one provided
+            if "exclude_keywords" not in template.keys():
+                template["exclude_keywords"] = []
+            elif type(template["exclude_keywords"]) is not list:
+                template["exclude_keywords"] = [template["exclude_keywords"]]
+
+            invoicetemplates.append(InvoiceTemplate(template))
 
     logger.info("Loaded %d templates from %s", len(invoicetemplates), folder)
 

--- a/src/invoice2data/extract/loader.py
+++ b/src/invoice2data/extract/loader.py
@@ -1,4 +1,3 @@
-import codecs
 import logging
 from collections import OrderedDict
 from pathlib import Path
@@ -48,12 +47,11 @@ def read_templates(folder: str = None):
     templatedirectory: Path = Path(folder)
 
     for yamlfile in sorted(templatedirectory.glob("**/*.yml")):
-        with codecs.open(str(yamlfile), encoding="utf-8") as templatefile:
-            try:
-                template = ordered_load(templatefile.read())
-            except yaml.parser.ParserError as error:
-                logger.warning(f"Failed to load {yamlfile.name} template:\n{error}")
-                continue
+        try:
+            template = ordered_load(yamlfile.read_text(encoding="utf-8"))
+        except yaml.parser.ParserError as error:
+            logger.warning(f"Failed to load {yamlfile.name} template:\n{error}")
+            continue
 
         template["template_name"] = yamlfile.name
 

--- a/src/invoice2data/extract/loader.py
+++ b/src/invoice2data/extract/loader.py
@@ -53,7 +53,7 @@ def read_templates(folder: str = None):
             logger.warning(f"Failed to load {yamlfile.name} template:\n{error}")
             continue
 
-        template["template_name"] = yamlfile.name
+        template["template_name"] = yamlfile.stem
 
         # Test if all required fields are in template
         if "keywords" not in template.keys():

--- a/src/invoice2data/extract/loader.py
+++ b/src/invoice2data/extract/loader.py
@@ -56,7 +56,7 @@ def read_templates(folder=None):
                 try:
                     template = ordered_load(template_file.read())
                 except yaml.parser.ParserError as error:
-                    logger.warning("Failed to load %s template:\n%s", name, error)
+                    logger.warning(f"Failed to load {name} template:\n{error}")
                     continue
 
             template["template_name"] = name
@@ -77,6 +77,6 @@ def read_templates(folder=None):
 
             invoicetemplates.append(InvoiceTemplate(template))
 
-    logger.info("Loaded %d templates from %s", len(invoicetemplates), folder)
+    logger.info(f"Loaded {len(invoicetemplates)} templates from {folder}")
 
     return invoicetemplates

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,0 +1,50 @@
+import shutil
+from pathlib import Path
+
+import pytest
+
+from invoice2data.extract.invoice_template import InvoiceTemplate
+from invoice2data.extract.loader import read_templates
+
+
+@pytest.fixture(autouse=True)
+def prepare_template(templatefile: Path) -> None:
+    templatefile.write_text(template_with_single_special_char, encoding="utf-8")
+
+
+@pytest.fixture
+def templatedirectory() -> Path:
+    templatedirectory = Path("tests/templatedirectory/")
+    templatedirectory.mkdir(parents=True)
+
+    yield templatedirectory
+
+    shutil.rmtree(templatedirectory, ignore_errors=True)
+
+
+@pytest.fixture
+def templatefile(templatedirectory: Path) -> Path:
+    return templatedirectory / "template.yml"
+
+
+def test_default_templates_are_loaded():
+    templates = read_templates()
+
+    assert len(templates) == 165
+    assert all(isinstance(template, InvoiceTemplate) for template in templates)
+
+
+def test_template_with_single_specialchar_is_loaded(templatedirectory: Path):
+    templates = read_templates(str(templatedirectory))
+
+    assert templates[0]["fields"]["single_specialchar"]["value"] == "ä"
+
+
+template_with_single_special_char = """
+keywords:
+  - Basic Test
+fields:
+  single_specialchar:
+    parser: static
+    value: ä
+"""

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -34,6 +34,15 @@ def test_template_with_missing_keywords_raises_valueerror(templatedirectory: Pat
     assert "keywords" in str(exc)
 
 
+def test_template_name_is_yaml_filename(templatedirectory: Path):
+    yamlfile = templatedirectory / "thisnameisimportant.yml"
+    yamlfile.write_text(template_with_single_special_char, encoding="utf-8")
+
+    templates = read_templates(str(templatedirectory))
+
+    assert templates[0]["template_name"] == "thisnameisimportant"
+
+
 def test_template_with_single_specialchar_is_loaded(templatedirectory: Path):
     yamlfile = templatedirectory / "specialchartemplate.yml"
     yamlfile.write_text(template_with_single_special_char, encoding="utf-8")


### PR DESCRIPTION
Thanks for your work. It was a good decision to drop encoding detection and simply treat all templatefiles as `utf-8`. This made my previous PR #446 also obsolete.

As I put some effort in improving the loader mechanism and make it easier to read and test, I propose these changes again without encoding detection.

I would have enhanced it further (e.g. using `pathlib.Path`), but the Python 2.7 compatibility stopped me. Are there plans to only support actively maintained Python versions in upcoming releases? I could help at that, too.