### PR TITLE
tests: custom: verify that missing fields don't get set

### DIFF
--- a/tests/custom/templates/basic.yml
+++ b/tests/custom/templates/basic.yml
@@ -15,6 +15,9 @@ fields:
     parser: regex
     regex: Total:\s*(\d+\.\d\d)
     type: float
+  missing:
+    parser: regex
+    regex: This field is missing (.*)
 options:
   currency: EUR
   date_formats:

--- a/tests/custom/templates/lines-basic.yml
+++ b/tests/custom/templates/lines-basic.yml
@@ -21,6 +21,11 @@ fields:
     start: Simple lines start
     end: Simple lines end
     line: ^(?P<number>.+)$
+  zero_lines:
+    parser: lines
+    start: Simple lines start
+    end: Simple lines end
+    line: ^Nonexistent lines pattern (?P<name>.+)$
   column_lines:
     parser: lines
     start: Columns start


### PR DESCRIPTION
```
It's to prevent breakages like the one fixed by the commit bc667cf4b452
("Don't set empty fields in output").
```