### PR TITLE
lines: support "rules" field for multiple sets of parsing regexes

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -137,6 +137,10 @@ This parser allows parsing selected invoice section as a set of lines
 sharing some pattern. Those can be e.g. invoice items (good or services)
 or VAT rates.
 
+Some companies may use multiple formats for their line-based data. In
+such cases multiple sets of parsing regexes can be added to the `rules`.
+Results from multiple `rules` get merged into a single array.
+
 It replaces `lines` plugin and should be preferred over it. It allows
 reusing in multiple `fields`.
 
@@ -148,6 +152,17 @@ Example for `fields`:
         start: Item\s+Discount\s+Price$
         end: \s+Total
         line: (?P<description>.+)\s+(?P<discount>\d+.\d+)\s+(?P<price>\d+\d+)
+
+    fields:
+      lines:
+        parser: lines
+        rules:
+          - start: Item\s+Discount\s+Price$
+            end: \s+Total
+            line: (?P<description>.+)\s+(?P<discount>\d+.\d+)\s+(?P<price>\d+\d+)
+          - start: Item\s+Price$
+            end: \s+Total
+            line: (?P<description>.+)\s+(?P<price>\d+\d+)
 
 ### Legacy regexes
 

--- a/tests/custom/lines-multiple-patterns.json
+++ b/tests/custom/lines-multiple-patterns.json
@@ -17,6 +17,13 @@
             { "pos": 6, "name": "Penguin" },
             { "pos": 7, "name": "Ostrich" }
         ],
+        "dimensions": [
+            { "pos": 1, "angle": 30, "length": 30 },
+            { "pos": 2, "angle": 45, "length": 40 },
+            { "pos": 3, "angle": 90, "length": 60 },
+            { "pos": 4, "length": 80, "angle": 135 },
+            { "pos": 5, "length": 100, "angle": 180 }
+        ],
         "currency": "EUR",
         "desc": "Invoice from Lines Tests"
     }

--- a/tests/custom/lines-multiple-patterns.txt
+++ b/tests/custom/lines-multiple-patterns.txt
@@ -5,6 +5,7 @@ Total: 50.00 EUR
 
 Lines with multiple patterns
 
+
 Lines start
 
 Group: Mammals
@@ -21,3 +22,15 @@ Subgroup: Flightless
 7. Ostrich
 
 Lines end
+
+
+No  Angle [°]  Length [cm]
+1   30         30
+2   45         40
+3   90         60
+Count: 3
+
+No  Length [cm]  Angle [°]
+4   80           135
+5   100          180
+Count: 2

--- a/tests/custom/templates/lines-multiple-patterns.yml
+++ b/tests/custom/templates/lines-multiple-patterns.yml
@@ -26,6 +26,23 @@ fields:
       - ^Subgroup:\s*(?P<subgroup>.+)$
     types:
       pos: int
+  dimensions:
+    parser: lines
+    rules:
+      - start: No.*Angle.*Length
+        end: Count
+        line: ^(?P<pos>\d+)\s+(?P<angle>\d+)\s+(?P<length>\d+)$
+        types:
+          pos: int
+          angle: int
+          length: int
+      - start: No.*Length.*Angle
+        end: Count
+        line: ^(?P<pos>\d+)\s+(?P<length>\d+)\s+(?P<angle>\d+)$
+        types:
+          pos: int
+          angle: int
+          length: int
 options:
   currency: EUR
   date_formats:


### PR DESCRIPTION
```
Sometimes companies use more than 1 format for line-parseable data. They
may randomly generate invoices with e.g.
1. Some extra columns that are used occasionally
2. Rearrange columns order

Such format changes may be too invasive to support parsing with e.g.
multiple "line" regexes.

This commit adds "rules" field support to the "lines" parser. It allows
defining multiple sets or regexes ("start", "end", "line" & friends) for
a single upper field.

Usage of "rules" is optional. Backward compatibility wiht existing
templates is preserved.
```