### PR TITLE
remove_accents: refactor to NFKD normalization

### DIFF
--- a/src/invoice2data/extract/invoice_template.py
+++ b/src/invoice2data/extract/invoice_template.py
@@ -82,7 +82,7 @@ class InvoiceTemplate(OrderedDict):
 
         # Remove accents
         if self.options["remove_accents"]:
-            optimized_str = unicodedata.normalize('NFKC', optimized_str).encode('ascii', 'ignore').decode('ascii')
+            optimized_str = unicodedata.normalize('NFKD', optimized_str).encode('ascii', 'ignore').decode('ascii')
 
         # Convert to lower case
         if self.options["lowercase"]:


### PR DESCRIPTION
Refactor the remove accents functions to NFKD normalization form. So référence get normalized to reference.

This fixes: #444 