### PR TITLE
tesseract: [FIX] pdf pre-processing

### DIFF
--- a/src/invoice2data/input/tesseract.py
+++ b/src/invoice2data/input/tesseract.py
@@ -2,6 +2,7 @@
 
 from distutils import spawn
 import tempfile
+import mimetypes
 
 from subprocess import Popen, PIPE, STDOUT, CalledProcessError, TimeoutExpired
 from subprocess import run
@@ -54,8 +55,10 @@ def to_text(path):
         "-append",
         "png:-",
     ]
-    if path.endswith(".pdf"):
-        # pre processing pdf file by converting to png
+    mt = mimetypes.guess_type(path)
+    if mt[0] == "application/pdf":
+        # tesseract does not support pdf files, pre-processing is needed.
+        logger.debug("PDF file detected, start pre-processing by converting to png")
         p1 = Popen(convert, stdout=PIPE)
         tess_input = "stdin"
         stdin = p1.stdout


### PR DESCRIPTION
Before this PR the mimetype of the input file was detected by it's extension.
It works fine for cli usage.

It fails when invoice2data is used as a library and a tempfile/stream is used as an input. (as there is no extension available)
Making it impossible to parse pdf files when using invoice2data  as a library. 
As tesseract cannot handle pdf files as an input. 

After this pr, the mimetype is also detected when using invoice2data as a library.

@m3nu , @rmilecki I'm consideirng this as a hotfix, so fasttracking this one.