### PR TITLE
replace distutils with shutil

### DIFF
--- a/src/invoice2data/input/pdftotext.py
+++ b/src/invoice2data/input/pdftotext.py
@@ -21,9 +21,9 @@ def to_text(path: str, area_details: dict = None):
         If pdftotext library is not found
     """
     import subprocess
-    from distutils import spawn  # py2 compat
+    import shutil
 
-    if spawn.find_executable("pdftotext"):  # shutil.which('pdftotext'):
+    if shutil.which('pdftotext'):
         cmd = ["pdftotext", "-layout", "-enc", "UTF-8"]
         if area_details is not None:
             # An area was specified

--- a/src/invoice2data/input/tesseract.py
+++ b/src/invoice2data/input/tesseract.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from distutils import spawn
+import shutil
 import tempfile
 import mimetypes
 
@@ -29,9 +29,9 @@ def to_text(path):
     """
 
     # Check for dependencies. Needs Tesseract and Imagemagick installed.
-    if not spawn.find_executable("tesseract"):
+    if not shutil.which("tesseract"):
         raise EnvironmentError("tesseract not installed.")
-    if not spawn.find_executable("convert"):
+    if not shutil.which("convert"):
         raise EnvironmentError("imagemagick not installed.")
 
     language = get_languages()


### PR DESCRIPTION
The package distutils is deprecated and slated for removal in Python 3.12. We are using the function find_executable that belongs to that package. We should instead be using which from the package shutil.