### PR TITLE
Performance update: match keywords on extracted_str

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -381,9 +381,7 @@ Look at the invoice and find the best identifying string. Tax number +
 company name are good options. Remember, *all* keywords need to be found
 for the template to be used.
 
-Keywords are compared *after* processing the extracted text. So if you
-use lowercase or remove-whitespace processing, adapt keywords
-accordingly.
+Keywords are compared *before* processing the extracted text.
 
 ### 4. First test run
 

--- a/src/invoice2data/extract/invoice_template.py
+++ b/src/invoice2data/extract/invoice_template.py
@@ -41,7 +41,7 @@ class InvoiceTemplate(OrderedDict):
     -------
     prepare_input(extracted_str)
         Input raw string and do transformations, as set in template file.
-    matches_input(optimized_str)
+    matches_input(extracted_str)
         See if string matches keywords set in template file
     parse_number(value)
         Parse number, remove decimal separator and add other options
@@ -101,21 +101,21 @@ class InvoiceTemplate(OrderedDict):
 
         return optimized_str
 
-    def matches_input(self, optimized_str: str) -> bool:
+    def matches_input(self, extracted_str: str) -> bool:
         """See if string matches all keyword patterns and no exclude_keyword patterns set in template file.
 
         Args:
-        optimized_str: String of the text from OCR of the pdf after applying options defined in the template.
+        extracted_str: String of the text from OCR of the pdf before applying options defined in the template.
 
         Return:
         Boolean
             - True if all keywords are found and none of the exclude_keywords are found.
             - False if either not all keywords are found or at least one exclude_keyword is found."""
 
-        if all([re.search(keyword, optimized_str) for keyword in self["keywords"]]):
+        if all([re.search(keyword, extracted_str) for keyword in self["keywords"]]):
             # All keyword patterns matched
             if self["exclude_keywords"]:
-                if any([re.search(exclude_keyword, optimized_str) for exclude_keyword in self["exclude_keywords"]]):
+                if any([re.search(exclude_keyword, extracted_str) for exclude_keyword in self["exclude_keywords"]]):
                     # At least one exclude_keyword matches
                     logger.debug("Template: %s. Keywords matched. Exclude keyword found!", self["template_name"])
                     return False

--- a/src/invoice2data/extract/templates/com/com.flipkart.WSRetail.yml
+++ b/src/invoice2data/extract/templates/com/com.flipkart.WSRetail.yml
@@ -2,12 +2,11 @@ issuer: Flipkart
 fields:
   amount: GrandTotal(\d+\.\d+)
   date: InvoiceDate:(\d{1,4}\-\d{1,2}\-\d{1,4})
-  #invoice_number: InvoiceNo:(\W\w+)
   invoice_number: InvoiceNo:(\S+)
   order_id: OrderID:(\w{2}\d{16,18})
 keywords:
 - flipkart
-- WSRetail
+- WS\s?Retail
 - OD
 
 

--- a/src/invoice2data/main.py
+++ b/src/invoice2data/main.py
@@ -96,7 +96,7 @@ def extract_data(invoicefile, templates=None, input_module=None):
 
     if templates is None:
         templates = read_templates()
-    templates = filter(lambda t: t.matches_input(t.prepare_input(extracted_str)), templates)
+    templates = filter(lambda t: t.matches_input(extracted_str), templates)
     templates = sorted(templates, key=lambda k: k['priority'], reverse=True)
     if not templates:
         logger.error("No template for %s", invoicefile)


### PR DESCRIPTION
Before this PR for each individual template an optimized string was generated.
This impacts the performance negatively, specifically if one has a lot of templates.


This PR greatly increases performance as an optimized_str is only generated on the matched template instead of on all templates.

On my local system, I realized a 2x performance increase.

:warning: Warning: Every performance increase comes at a cost. It might break some templates.