### PR TITLE
[IMP] return all the options

### DIFF
--- a/src/invoice2data/extract/invoice_template.py
+++ b/src/invoice2data/extract/invoice_template.py
@@ -245,6 +245,7 @@ class InvoiceTemplate(OrderedDict):
                     output[k] = result
 
         output["currency"] = self.options["currency"]
+        output["options"] = self.options
 
         # Run plugins:
         for plugin_keyword, plugin_func in PLUGIN_MAPPING.items():


### PR DESCRIPTION
hi all,

Well, first thanks for this great library ! I'm just developed a little module on top of this library, and it works like a charm. 

I face a minor issue. Some PDF have some date format ``%d/%m/%y`` and other have format date ``%m/%d/%y``. 
So, I used the ``date_format``  configuration in my templates to parse correctly the date

```
options:
  date_formats: '%d/%m/%y'
````

The problem I face is that the result in json doesn't mention the format of the date. For exemple here is a result : 

```
{
    "issuer": "My Supplier",
    "amount": 671.37,
    "invoice_number": "792437", 
    "date": "07/02/23", 
    "currency": "EUR", 
    "desc": "Invoice from My Supplier",
}
```
In my application, I can not know if the date is '2023-02-07' or '2023-07-02'. 
For the time being, as a work around, I duplicated the date_format and added it in the ``fields``  section. See : 

```
fields:
  date_format:
    parser: static
    value: '%d/%m/%y'
```

However, that trivial PR could avoid that duplication.

New Result : 
```
{
    "issuer": "My Supplier",
    "amount": 671.37,
    "invoice_number": "792437",
    "date": "07/02/23",
    "currency": "EUR",
    "desc": "Invoice from My Supplier",
    "options": {
        "remove_whitespace": False,
        "remove_accents": False,
        "lowercase": False,
        "currency": "EUR",
        "date_formats": "%d/%m/%y",
        "languages": [],
    },
}

```

Please, let me know if I missed something.
