### PR TITLE
remove comment to improve coverage

### DIFF
--- a/src/invoice2data/extract/parsers/__interface__.py
+++ b/src/invoice2data/extract/parsers/__interface__.py
@@ -1,5 +1,3 @@
-# SPDX-License-Identifier: MIT
-
 """
 Interface for fields parsers.
 


### PR DESCRIPTION
Fixes coverage of 0%:

`/opt/hostedtoolcache/Python/3.10.10/x64/lib/python3.10/site-packages/invoice2data/extract/parsers/__interface__.py       1      1     0%`