### PR TITLE
Improve Template Error Messages

### DIFF
--- a/src/invoice2data/extract/invoice_template.py
+++ b/src/invoice2data/extract/invoice_template.py
@@ -63,7 +63,10 @@ class InvoiceTemplate(OrderedDict):
             self.options.update(self["options"])
 
         for lang in self.options["languages"]:
-            assert len(lang) == 2, "lang code must have 2 letters"
+            assert len(lang) == 2, (
+                "Error in Template %s lang code must have 2 letters"
+                % self["template_name"]
+            )
 
         # Set issuer, if it doesn't exist.
         if "issuer" not in self.keys():
@@ -90,7 +93,10 @@ class InvoiceTemplate(OrderedDict):
 
         # Specific replace
         for replace in self.options["replace"]:
-            assert len(replace) == 2, "A replace should be a list of exactly 2 elements."
+            assert len(replace) == 2, (
+                "Error in Template %s A replace should be a list of exactly 2 elements."
+                % self["template_name"]
+            )
             optimized_str = re.sub(replace[0], replace[1], optimized_str)
 
         return optimized_str
@@ -121,9 +127,10 @@ class InvoiceTemplate(OrderedDict):
             return False
 
     def parse_number(self, value):
-        assert (
-            value.count(self.options["decimal_separator"]) < 2
-        ), "Decimal separator cannot be present several times"
+        assert value.count(self.options["decimal_separator"]) < 2, (
+            "Error in Template %s Decimal separator cannot be present several times"
+            % self["template_name"]
+        )
         # replace decimal separator by a |
         amount_pipe = value.replace(self.options["decimal_separator"], "|")
         # remove all possible thousands separators

--- a/src/invoice2data/extract/parsers/lines.py
+++ b/src/invoice2data/extract/parsers/lines.py
@@ -23,7 +23,9 @@ def parse_line(patterns, line):
 
 def parse_block(template, field, settings, content):
     # Validate settings
-    assert "line" in settings, "Line regex missing"
+    assert "line" in settings, (
+        "Error in Template %s Line regex missing" % template["template_name"]
+    )
 
     logger.debug(
         "START lines block content ========================\n%s", content
@@ -125,8 +127,12 @@ def parse_by_rule(template, field, rule, content):
     settings.update(rule)
 
     # Validate settings
-    assert "start" in settings, "Lines start regex missing"
-    assert "end" in settings, "Lines end regex missing"
+    assert "start" in settings, (
+        "Error in Template %s Lines start regex missing" % template["template_name"]
+    )
+    assert "end" in settings, (
+        "Error in Template %s Lines end regex missing" % template["template_name"]
+    )
 
     blocks_count = 0
     lines = []

--- a/src/invoice2data/extract/plugins/tables.py
+++ b/src/invoice2data/extract/plugins/tables.py
@@ -21,9 +21,15 @@ def extract(self, content, output):
         table = plugin_settings
 
         # Validate settings
-        assert "start" in table, "Table start regex missing"
-        assert "end" in table, "Table end regex missing"
-        assert "body" in table, "Table body regex missing"
+        assert "start" in table, (
+            "Error in Template %s Table start regex missing" % self["template_name"]
+        )
+        assert "end" in table, (
+            "Error in Template %s Table end regex missing" % self["template_name"]
+        )
+        assert "body" in table, (
+            "Error in Template %s Table body regex missing" % self["template_name"]
+        )
 
         start = re.search(table["start"], content)
         end = re.search(table["end"], content)


### PR DESCRIPTION
Using invoice2data as I lib.
Before I got this error message in the upstream application.
![image](https://user-images.githubusercontent.com/11499387/224480874-dd1bffa6-e5b2-4563-97cf-a3960938d1a8.png)

In the frontend the logger is not visible.
It is more usefull to show which template contains the error.