### PR TITLE
Show invalid parser as error in the logger

### DIFF
--- a/src/invoice2data/extract/invoice_template.py
+++ b/src/invoice2data/extract/invoice_template.py
@@ -223,11 +223,11 @@ class InvoiceTemplate(OrderedDict):
                         if value:
                             output[k] = value
                         else:
-                            logger.error("Failed to parse field %s with parser %s", k, v["parser"])
+                            logger.warning("Failed to parse field %s with parser %s", k, v["parser"])
                     else:
-                        logger.warning("Field %s has unknown parser %s set", k, v["parser"])
+                        logger.error("Field %s has unknown parser %s set", k, v["parser"])
                 else:
-                    logger.warning("Field %s doesn't have parser specified", k)
+                    logger.error("Field %s doesn't have parser specified", k)
             elif k.startswith("static_"):
                 logger.debug("field=%s | static value=%s", k, v)
                 output[k.replace("static_", "")] = v


### PR DESCRIPTION
Change logger levels.

1. In case an template specifies no or an invalid parser show it in the logger.

(This is usefull when someone wants to commit an template, pytest on hg actions will show the error).
The user will then be aware that the template needs fixing.

2. In case an invoice file does not return a value, only show a warning.
In #428 is a template which support multiple invoice layouts.  In some cases the website field is not matched. This is intentional. This should only show as a warning in the logger. This is not an error that needs immediate fixing.
