### PR TITLE
Remove empty items from list

### DIFF
--- a/src/invoice2data/extract/parsers/regex.py
+++ b/src/invoice2data/extract/parsers/regex.py
@@ -47,6 +47,7 @@ def parse(template, field, settings, content, legacy=False):
             result[k] = template.coerce_type(v, settings["type"])
 
     if "group" in settings:
+        result = list(filter(None, result))
         if settings["group"] == "sum":
             result = sum(result)
         elif settings["group"] == "min":


### PR DESCRIPTION
Fixes #496 
Min / max functions fails when there is a none type in the matching group.