### PR TITLE
Fix custom log handler

### DIFF
--- a/src/invoice2data/main.py
+++ b/src/invoice2data/main.py
@@ -88,8 +88,10 @@ class ColorLogFormatter(logging.Formatter):
 
 stream_handler = logging.StreamHandler()
 stream_handler.setFormatter(ColorLogFormatter())
-logger.addHandler(stream_handler)
 logger.propagate = False
+
+if not logger.handlers:
+    logger.addHandler(stream_handler)
 
 
 def extract_data(invoicefile, templates=None, input_module=None):


### PR DESCRIPTION
Only load the custom log handler (for easier cli debugging) when there is no logging handler present.
closes #504 