### PR TITLE
Avoid UnboundLocalError when exception is raised

### DIFF
--- a/src/invoice2data/extract/loader.py
+++ b/src/invoice2data/extract/loader.py
@@ -77,6 +77,7 @@ def read_templates(folder=None):
                         tpl = json.loads(template_file.read())
                     except ValueError as error:
                         logger.warning("json Loader Failed to load %s template:\n%s", name, error)
+                        continue
             tpl["template_name"] = name
 
             # Test if all required fields are in template


### PR DESCRIPTION
Adding `continue` to the except block, otherwise an `UnboundLocalError: local variable 'tpl' referenced before assignment` is thrown when trying to assign `tpl["template_name"] = name` after `json.loads()` raised an exception.

@bosd I think reading the templates should not fail completely because of one invalid template. Maybe we could also be more sensitive about the file types and only try `json.loads` for `.json` files instead of every file except .yml files (and for other file types raise a warning that only .yml and .json are supported)? What do you think about this?