### PR TITLE
custom templates: drop unused coding info from custom templates

### DIFF
--- a/tests/custom/templates/basic.yml
+++ b/tests/custom/templates/basic.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: MIT
 issuer: Basic Test
 keywords:

--- a/tests/custom/templates/lines-basic.yml
+++ b/tests/custom/templates/lines-basic.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: MIT
 issuer: Lines Tests
 keywords:

--- a/tests/custom/templates/lines-blocks.yml
+++ b/tests/custom/templates/lines-blocks.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: MIT
 issuer: Lines Tests
 keywords:

--- a/tests/custom/templates/lines-multiple-patterns.yml
+++ b/tests/custom/templates/lines-multiple-patterns.yml
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: MIT
 issuer: Lines Tests
 keywords:


### PR DESCRIPTION
Leftover from previous removal of these obsolete lines.