### PR TITLE
loader: require .json extension and allow .yaml extension

### DIFF
--- a/src/invoice2data/extract/loader.py
+++ b/src/invoice2data/extract/loader.py
@@ -72,12 +72,14 @@ def read_templates(folder=None):
                     except YAMLError as error:
                         logger.warning("Failed to load %s template:\n%s", name, error)
                         continue
-                else:
+                elif name.endswith(".json"):
                     try:
                         tpl = json.loads(template_file.read())
                     except ValueError as error:
                         logger.warning("json Loader Failed to load %s template:\n%s", name, error)
                         continue
+                else:
+                    continue
             tpl["template_name"] = name
 
             # Test if all required fields are in template

--- a/src/invoice2data/extract/loader.py
+++ b/src/invoice2data/extract/loader.py
@@ -66,7 +66,7 @@ def read_templates(folder=None):
             with codecs.open(
                 os.path.join(path, name), encoding="utf-8"
             ) as template_file:
-                if name.endswith(".yml"):
+                if name.endswith((".yaml", ".yml")):
                     try:
                         tpl = load(template_file.read(), Loader=SafeLoader)
                     except YAMLError as error:


### PR DESCRIPTION
```
loader: allow YAML templates with .yaml extension

Oficially suggested extension for YAML files is .yaml. Accept it.
```
```
loader: require .json extension for JSON files

Trying to parse every file other than *.yml as JSON file isn't the best
idea. It wastes time on trying to parse non-template files. It produces
warnings like "json Loader Failed to load (...)template" for files that
were never meant to be templates. It's a bad pracice in general.

Check for file extension before using json.loads().
```