### PR TITLE
Clean up some build dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,8 +31,6 @@ license_file = LICENSE.txt
 
 [options]
 setup_requires =
-  pip >= 10
-  pytest-runner
   setuptools_git
 install_requires =
   pillow


### PR DESCRIPTION
While `pip` and `pytest-runner` could be development dependencies, I don't think they are needed for the actual build by setuptools. I'm hoping to clean this up to simplify in a small way packaging this in [nixpkgs](https://github.com/NixOS/nixpkgs).