### PR TITLE
TUTORIAL: Add "vatin" to standard fields

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -79,6 +79,7 @@ Standard fields:
 - `date`: the date invoice was issued
 - `invoice_number`: unique number assigned to invoice by an issuer
 - `amount`: total amount (with taxes)
+- `vatin`: [VAT identification number](https://en.wikipedia.org/wiki/VAT_identification_number)
 
 ### Parser `regex`
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -79,7 +79,7 @@ Standard fields:
 - `date`: the date invoice was issued
 - `invoice_number`: unique number assigned to invoice by an issuer
 - `amount`: total amount (with taxes)
-- `vatin`: [VAT identification number](https://en.wikipedia.org/wiki/VAT_identification_number)
+- `vat`: [VAT identification number](https://en.wikipedia.org/wiki/VAT_identification_number)
 
 ### Parser `regex`
 


### PR DESCRIPTION
```
In most countries end customers pay a VAT (value-added tax). Companies
issuing invoices with VAT need to have a unique identification number
assigned. Local names and abbreviations of those numbers differ across
countries (UID, DIČ, CVR, CBL, NIP, NIF, etc.).

European Union seems to reference those numbers as "VAT identification
numbers". Some open projects like Wikipedia and OpenStreetMap use
"vatin" abbreviation for it. Add field of the same name to the TUTORIAL.
```