### PR TITLE
Support zero values also in legacy syntax

### DIFF
--- a/src/invoice2data/extract/invoice_template.py
+++ b/src/invoice2data/extract/invoice_template.py
@@ -246,10 +246,10 @@ class InvoiceTemplate(OrderedDict):
                 else:
                     result = parsers.regex.parse(self, k, {"regex": v}, optimized_str, True)
 
-                if not result:
-                    logger.warning("regexp for field %s didn't match", k)
-                else:
+                if result or result == 0.0:
                     output[k] = result
+                else:
+                    logger.warning("regexp for field %s didn't match", k)
 
         output["currency"] = self.options["currency"]
 


### PR DESCRIPTION
https://github.com/invoice-x/invoice2data/pull/507 fixed the issue with zero values reported in https://github.com/invoice-x/invoice2data/issues/505 but not for legacy syntax.