### PR TITLE
Use B+8 digits format for Spanish VAT IDs

### DIFF
--- a/src/invoice2data/extract/templates/es/com.pepephone.yml
+++ b/src/invoice2data/extract/templates/es/com.pepephone.yml
@@ -4,7 +4,7 @@ fields:
   amount_untaxed: Total\s\(base\simponible\)\s+(\d+,\d{2})
   date: Fecha\sde\semisión:\s+(\d{2}/\d{2}/\d{4})
   invoice_number: Número\sde\sfactura:\s+(\d+)
-  static_vat: ESB85033470
+  static_vat: B85033470
   vat_rate: Impuesto\s+\(IVA\s+(.+)%\)
   address: CIF:\s+[A-Z0-9]+\s+(.+España)
   static_partner_name: PEPEMOBILE S.L.

--- a/src/invoice2data/extract/templates/es/es.digimobile.yml
+++ b/src/invoice2data/extract/templates/es/es.digimobile.yml
@@ -4,7 +4,7 @@ fields:
   amount_untaxed: IMPORTE\s+\(base\s+imponible\)\s+(\d+,\d{2})
   date: Fecha\s+de\s+emisión\s+(\d{2}/\d{2}/\d{4})
   invoice_number: FACTURA\s+Número:\s+([A-Z0-9]+)
-  static_vat: ESB84919760
+  static_vat: B84919760
   vat_rate: IMPUESTOS\s+\((\d+\.\d{2})%\s+IVA\)
   address: Domicilio\s+Social\s+en\s+(.+\(Madrid\))
   static_partner_name: DIGI Spain Telecom, S.L.U.


### PR DESCRIPTION
The ES prefix is only for intracommunitary merchants, but these two are ISPs and their VAT IDs can't be found on VIES (https://www2.agenciatributaria.gob.es/wlpl/GROI-JDIT/ConsultaOperadorSedeGroiServlet). VIES is the website that the Spanish tax agency has for checking intracommunitary merchants.

The following Wikipedia page (in Spanish)  describes the format for CIFs:

https://es.wikipedia.org/wiki/C%C3%B3digo_de_identificaci%C3%B3n_fiscal

DIGI And Pepephone belong in the 'B' category and their CIF is B + 8, shouldn't start with ES