### PR TITLE
Add parsing for invoices from Amazon.es

### DIFF
--- a/src/invoice2data/extract/templates/es/es.amazon.yml
+++ b/src/invoice2data/extract/templates/es/es.amazon.yml
@@ -3,26 +3,10 @@ fields:
   amount: Total\s+(\d+,\d{2})\s€\s+IVA
   amount_untaxed: \(IVA\s+excluido\)\s+\d+%\s+(\d+,\d{2})\s€
   date: entrega\s+(\d+\s+[A-z]+\s+\d+)\s+
-  invoice_number: Número\s+de\s+la\s+factura\s+([A-Z0-9]+)
-  vat:
-    parser: regex
-    regex:
-      - (W0184081H)
-      - (LU20260743)
-    group: first
+  invoice_number: Número\s+de\s+la\s+factura\s+([A-Z0-9\-]+)
+  vat: Vendido\s+por\s+.+\s+IVA\s+([A-Z0-9]+)
   vat_rate: \(IVA\s+excluido\)\s+(\d+)%
-  address:
-    parser: regex
-    regex:
-      - (Calle de Ramírez de Prado 5, 28045 Madrid, España)
-      - (38 avenue John F. Kennedy, L-1855 Luxemburgo)
-    group: first
-  partner_name:
-    parser: regex
-    regex:
-      - (Amazon EU S.à r.l., Sucursal en España)
-      - (Amazon EU S.à r.l.)
-    group: first
+  partner_name: Vendido\s+por\s+(.+)\s+IVA\s+[A-Z0-9]+
 keywords:
   - LU20260743
   - €

--- a/src/invoice2data/extract/templates/es/es.amazon.yml
+++ b/src/invoice2data/extract/templates/es/es.amazon.yml
@@ -1,0 +1,34 @@
+issuer: amazon.es
+fields:
+  amount: Total\s+(\d+,\d{2})\s€\s+IVA
+  amount_untaxed: \(IVA\s+excluido\)\s+\d+%\s+(\d+,\d{2})\s€
+  date: entrega\s+(\d+\s+[A-z]+\s+\d+)\s+
+  invoice_number: Número\s+de\s+la\s+factura\s+([A-Z0-9]+)
+  vat:
+    parser: regex
+    regex:
+      - (W0184081H)
+      - (LU20260743)
+    group: first
+  vat_rate: \(IVA\s+excluido\)\s+(\d+)%
+  address:
+    parser: regex
+    regex:
+      - (Calle de Ramírez de Prado 5, 28045 Madrid, España)
+      - (38 avenue John F. Kennedy, L-1855 Luxemburgo)
+    group: first
+  partner_name:
+    parser: regex
+    regex:
+      - (Amazon EU S.à r.l., Sucursal en España)
+      - (Amazon EU S.à r.l.)
+    group: first
+keywords:
+  - LU20260743
+  - €
+  - factura
+options:
+  currency: EUR
+  date_formats:
+    - '%d %B %Y'
+  decimal_separator: ','

--- a/src/invoice2data/extract/templates/es/es.amazon.yml
+++ b/src/invoice2data/extract/templates/es/es.amazon.yml
@@ -2,7 +2,7 @@ issuer: amazon.es
 fields:
   amount: Total\s+(\d+,\d{2})\s€\s+IVA
   amount_untaxed: \(IVA\s+excluido\)\s+\d+%\s+(\d+,\d{2})\s€
-  date: entrega\s+(\d+\s+[A-z]+\s+\d+)\s+
+  date: Fecha\s+de\s+la\s+entrega\s+(\d+\s+[A-z]+\s+\d+)\s+
   invoice_number: Número\s+de\s+la\s+factura\s+([A-Z0-9\-]+)
   vat: Vendido\s+por\s+.+\s+IVA\s+([A-Z0-9]+)
   vat_rate: \(IVA\s+excluido\)\s+(\d+)%


### PR DESCRIPTION
This PR adds parsing of Amazon.es invoices. I couldn't figure out how to add addresses from third party sellers, Amazon.es invoices have three columns (commercial address, shipping address and seller address), but each line of an address is in a separate row and couldn't come up with a regex that could capture that.