### PR TITLE
Refactor Template matching use `in` function.

### DIFF
--- a/src/invoice2data/extract/invoice_template.py
+++ b/src/invoice2data/extract/invoice_template.py
@@ -128,24 +128,24 @@ class InvoiceTemplate(OrderedDictType[str, Any]):
 
         Returns:
             bool: True if the extracted string matches the template keywords,
-                  False otherwise.
+                False otherwise.
         """
-        if all([re.search(keyword, extracted_str) for keyword in self["keywords"]]):
-            # All keyword patterns matched
+        if all([keyword in extracted_str for keyword in self["keywords"]]):
+            # All keywords found
             if self["exclude_keywords"]:
                 if any(
                     [
-                        re.search(exclude_keyword, extracted_str)
+                        exclude_keyword in extracted_str
                         for exclude_keyword in self["exclude_keywords"]
                     ]
                 ):
-                    # At least one exclude_keyword matches
+                    # At least one exclude_keyword found
                     logger.debug(
                         "Template: %s | Keywords matched. Exclude keyword found!",
                         self["template_name"],
                     )
                     return False
-            # No exclude_keywords or none match, template is good
+            # No exclude_keywords or none found, template is good
             logger.debug(
                 "Template: %s | Keywords matched. No exclude keywords found.",
                 self["template_name"],

--- a/src/invoice2data/extract/templates/com/com.flipkart.WSRetail.json
+++ b/src/invoice2data/extract/templates/com/com.flipkart.WSRetail.json
@@ -6,7 +6,7 @@
     "invoice_number": "InvoiceNo:(\\S+)",
     "order_id": "OrderID:(\\w{2}\\d{16,18})"
   },
-  "keywords": ["flipkart", "WS\\s?Retail", "OD"],
+  "keywords": ["flipkart", "WS Retail", "OD"],
   "options": {
     "currency": "INR",
     "remove_whitespace": true

--- a/src/invoice2data/extract/templates/nl/nl.be.coolblue.yml
+++ b/src/invoice2data/extract/templates/nl/nl.be.coolblue.yml
@@ -107,7 +107,7 @@ fields:
           price_subtotal: float
 keywords:
   - Coolblue
-  - (NL810433941B01|BE0867686774)
+  - Klantnummer
   - factuur
   - €
 options:


### PR DESCRIPTION
Use pythons `in` function for template matching of keywords.
We only need to know if the keywords is thee.
We don't need the advanced features and addicitional cost of regexes.

`in` function is python is generally much faster then a regular expression.
https://stackoverflow.com/questions/19911508/python-speed-for-in-vs-regular-expression