### PR TITLE
Support sum and group options in Table plugin

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -308,6 +308,17 @@ The plugin uses the following properties:
 * **`end`**: A regex to identify the end of the table.
 * **`body`**: A regex with named capture groups to extract the data. The names of the capture groups will become the field names in the output.
 
+**Optional Properties**
+
+* **`type`**:  Specifies the data type of the extracted value. Can be `int`, `float`, or `date`.
+* **`group`**: Defines how to handle multiple matches. Options include:
+    * `sum`: Sum the values.
+    * `min`: Return the minimum value.
+    * `max`: Return the maximum value.
+    * `first`: Return the first match.
+    * `last`: Return the last match.
+    * `join`: Join the matches into a single string.
+
 The plugin will try to match the `body` regex to the text between the `start` and `end` markers.
 
 **Example Invoice**
@@ -339,7 +350,9 @@ headings. A template to capture these fields may look like:
     tables:
       - start: Hotel Details\s+Check In\s+Check Out\s+Rooms
         end: Booking ID
-        body: (?P<hotel_details>[\S ]+),\s+(?P<date_check_in>\d{1,2}\/\d{1,2}\/\d{4})\s+(?P<date_check_out>\d{1,2}\/\d{1,2}\/\d{4})\s+(?P<amount_rooms>\d+)
+        body: (?P<hotel_details>[\S ]+),\s+(?P<date_check_in>\d{1,2}\/\d{1,2}\/\d{4})\s+(?P<date_check_out>\d{1,2}\/\d{1,2}\/\d{4})\s+(?P<qty_rooms>\d+)
+        types:
+          qty_rooms: int
       - start: Booking ID\s+Payment Mode
         end: DESCRIPTION
         body: (?P<booking_id>\w+)\s+(?P<payment_method>(?:\w+ ?)*)
@@ -349,6 +362,19 @@ The plugin supports multiple tables per invoice as seen in the example.
 By default, all fields are parsed as strings. The `tables` plugin
 supports the `amount` and `date` field naming conventions to convert
 data types.
+
+The table plugin supports the grouping options in case there are multiple matches.
+This is usefull when one wants to sum the numbers in a column, Example:
+```yaml
+    tables:
+      - start: Basic example to sum a number
+        end: with the help of the table plugin
+        body: (?P<random_num_to_sum>\d+\.\d+)
+        fields:
+          random_num_to_sum:
+            group: sum
+            type: float
+```
 
 ### Options
 

--- a/src/invoice2data/extract/parsers/regex.py
+++ b/src/invoice2data/extract/parsers/regex.py
@@ -19,6 +19,8 @@ from typing import Dict
 from typing import List
 from typing import Optional
 
+from ..utils import _apply_grouping
+
 
 logger = logging.getLogger(__name__)
 
@@ -104,30 +106,6 @@ def _apply_type_coercion(
     if "type" in settings:
         for k, v in enumerate(result):
             result[k] = template.coerce_type(v, settings["type"])
-    return result
-
-
-def _apply_grouping(settings: Dict[str, Any], result: Any) -> Optional[Any]:
-    """Apply grouping to the extracted values."""
-    if "group" in settings:
-        result = list(filter(None, result))
-        if result:
-            if settings["group"] == "sum":
-                result = sum(result)
-            elif settings["group"] == "min":
-                result = min(result)
-            elif settings["group"] == "max":
-                result = max(result)
-            elif settings["group"] == "first":
-                result = result[0]
-            elif settings["group"] == "last":
-                result = result[-1]
-            elif settings["group"] == "join":
-                joined = " ".join(str(v) for v in result) if result else ""
-                result = [joined]
-            else:
-                logger.warning("Unsupported grouping method: %s", settings["group"])
-                return None
     return result
 
 

--- a/src/invoice2data/extract/utils.py
+++ b/src/invoice2data/extract/utils.py
@@ -1,0 +1,33 @@
+"""This module abstracts utilities for processing of the extracted values."""
+
+from logging import getLogger
+from typing import Any
+from typing import Dict
+from typing import Optional
+
+
+logger = getLogger(__name__)
+
+
+def _apply_grouping(settings: Dict[str, Any], result: Any) -> Optional[Any]:
+    """Apply grouping to the extracted values."""
+    if "group" in settings:
+        result = list(filter(None, result))
+        if result:
+            if settings["group"] == "sum":
+                result = sum(result)
+            elif settings["group"] == "min":
+                result = min(result)
+            elif settings["group"] == "max":
+                result = max(result)
+            elif settings["group"] == "first":
+                result = result[0]
+            elif settings["group"] == "last":
+                result = result[-1]
+            elif settings["group"] == "join":
+                joined = " ".join(str(v) for v in result) if result else ""
+                result = [joined]
+            else:
+                logger.warning("Unsupported grouping method: %s", settings["group"])
+                return None
+    return result

--- a/tests/custom/table-groups.json
+++ b/tests/custom/table-groups.json
@@ -1,0 +1,20 @@
+[
+  {
+    "issuer": "Table Groups Tests",
+    "date": "2024-12-20",
+    "invoice_number": "007/10/2024",
+    "amount": 123.4,
+    "currency": "EUR",
+    "hotel_details": [
+      "OYO 4189 Resort Nanganallur",
+      "OYO 4189 Resort Nanganallur Suite A"
+    ],
+    "date_check_in": "2024-01-08",
+    "date_check_out": "2024-12-31",
+    "qty_rooms": 2,
+    "line_tax_percent": ["1%", "2%", "0%"],
+    "lamount_tax": ["3.00", "2.00", "0.00"],
+    "random_num_to_sum": 11.01,
+    "desc": "Invoice from Table Groups Tests"
+  }
+]

--- a/tests/custom/table-groups.txt
+++ b/tests/custom/table-groups.txt
@@ -1,0 +1,31 @@
+Issue date: 2024-12-20
+Issuer: Table Group Tests
+Invoice number: 007/10/2024
+Total: 123.40 EUR
+
+Table basic
+
+Simple table start
+Tax precentage     amount   qty
+1%                 3.00     7.00
+2%                  2.00    4.00
+0%                  0.00    0.01
+Simple table end
+
+
+
+Sample data below to test advanced grouping functions of table parser.
+
+Guest Name: Sanjay
+
+Hotel Details                                                   Check In            Check Out       Rooms
+OYO 4189 Resort Nanganallur,                                    01/08/2024          01/01/2018      1
+OYO 4189 Resort Nanganallur Suite A,                            31/12/2017          31/12/2024      1
+25,Vembuliamman Koil Street,, Pazhavanthangal, Chennai
+                                                                    Booking ID              Payment Mode
+                                                                    IBZY2087                Cash at Hotel
+
+
+invoice2data --input-reader=text --debug ./table-groups.txt
+
+invoice2data ./table-groups.txt --debug -t ./templates

--- a/tests/custom/templates/table-groups.yml
+++ b/tests/custom/templates/table-groups.yml
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: MIT
+issuer: Table Groups Tests
+keywords:
+  - Table basic
+  - Simple table start
+
+tables:
+  - start: Hotel Details\s+Check In\s+Check Out\s+Rooms
+    end: Booking ID
+    body: (?P<hotel_details>[\S ]+),\s+(?P<date_check_in>\d{1,2}\/\d{1,2}\/\d{4})\s+(?P<date_check_out>\d{1,2}\/\d{1,2}\/\d{4})\s+(?P<qty_rooms>\d)
+    types:
+      qty_rooms: int
+    fields:
+      qty_rooms:
+        group: sum
+      date_check_in:
+        group: first
+      date_check_out:
+        group: last
+  - start: Tax precentage     amount   qty
+    end: Simple table end
+    body: (?P<line_tax_percent>\d[%])\s+(?P<lamount_tax>\d\.\d{2})\s+(?P<random_num_to_sum>\d\.\d{2})
+    fields:
+      random_num_to_sum:
+        group: sum
+        # type: float # This is also supported
+    types:
+      random_num_to_sum: float # this is supported
+
+fields:
+  date:
+    parser: regex
+    regex: Issue date:\s*(\d{4}-\d{2}-\d{2})
+    type: date
+  invoice_number:
+    parser: regex
+    regex: Invoice number:\s*([\d/]+)
+  amount:
+    parser: regex
+    regex: Total:\s*(\d+\.\d\d)
+    type: float
+options:
+  currency: EUR
+  date_formats:
+    - "%Y-%m-%d"
+  decimal_separator: "."


### PR DESCRIPTION
With this PR it is possible to use the grouping options in the table plugin.

To be able to abstract and re-use the grouping code. It is now moved to it's own file.
Documentation has been updated.
Included tests.

Closes: #178 
