### PR TITLE
style: modernize type hints to PEP 585/604

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,10 +160,6 @@ extend-ignore = [
     "S101",   # use of assert Activate later
     "S603",
     "UP031",  # Use fstring instead of % identifier
-    "UP006",  # PEP 585 (list vs List): defer typing modernization to its own PR
-    "UP007",  # PEP 604 (X | Y vs Optional/Union): defer typing modernization
-    "UP035",  # deprecated typing imports: defer typing modernization to its own PR
-    "UP038",  # PEP 604 isinstance: defer typing modernization to its own PR
     "E501",   # fix this when updating docstrings
     # "DOC106",
     # "DOC107",

--- a/src/invoice2data/__main__.py
+++ b/src/invoice2data/__main__.py
@@ -9,10 +9,6 @@ from copy import deepcopy
 from os.path import join
 from typing import Any
 from typing import ClassVar
-from typing import Dict
-from typing import List
-from typing import Optional
-from typing import Tuple
 
 import click
 
@@ -110,9 +106,9 @@ if not logger.handlers:
 
 def extract_data(
     invoicefile: str,
-    templates: Optional[List[InvoiceTemplate]] = None,
+    templates: list[InvoiceTemplate] | None = None,
     input_module: Any = None,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Extracts structured data from PDF/image invoices.
 
     This function uses the text extracted from a PDF file or image and
@@ -123,14 +119,14 @@ def extract_data(
 
     Args:
         invoicefile (str): Path of electronic invoice file in PDF, JPEG, PNG
-        templates (Optional[List[InvoiceTemplate]]): List of instances of class `InvoiceTemplate`.
+        templates (list[InvoiceTemplate] | None): List of instances of class `InvoiceTemplate`.
                                             Templates are loaded using `read_template` function in `loader.py`.
         input_module (Any, optional): Library to be used to extract text
                                         from the given `invoicefile`.
                                         Choices: {'pdftotext', 'pdfminer', 'tesseract', 'text'}.
 
     Returns:
-        Dict[str, Any]: Extracted and matched fields, or False if no template matches.
+        dict[str, Any]: Extracted and matched fields, or False if no template matches.
 
     Notes:
         Import the required `input_module` when using invoice2data as a library.
@@ -192,14 +188,14 @@ def extract_data(
 
 def extract_data_fallback_ocrmypdf(
     invoicefile: str,
-    templates: List[InvoiceTemplate],
+    templates: list[InvoiceTemplate],
     input_module: Any,
-) -> Tuple[str, str, List[InvoiceTemplate]]:
+) -> tuple[str, str, list[InvoiceTemplate]]:
     logger.debug("Trying OCR extraction with ocrmypdf")
     extracted_str = ocrmypdf.to_text(invoicefile)
 
     # Convert the filter object to a list
-    templates_matched: List[InvoiceTemplate] = list(
+    templates_matched: list[InvoiceTemplate] = list(
         filter(lambda t: t.matches_input(extracted_str), templates)
     )
     templates_matched.sort(key=lambda k: k["priority"], reverse=True)
@@ -268,17 +264,17 @@ def extract_data_fallback_ocrmypdf(
 )
 @click.version_option()
 def main(
-    input_reader: Optional[str],
+    input_reader: str | None,
     output_format: str,
     output_date_format: str,
     output_name: str,
     debug: bool,
-    copy: Optional[str],
-    move: Optional[str],
+    copy: str | None,
+    move: str | None,
     filename_format: str,
-    template_folder: Optional[str],
+    template_folder: str | None,
     exclude_built_in_templates: bool,
-    input_files: Tuple[Any, ...],
+    input_files: tuple[Any, ...],
 ) -> None:
     """Extract data from PDF files and output it in a structured format."""
     if debug:
@@ -315,8 +311,8 @@ def main(
 
 
 def _load_templates(
-    template_folder: Optional[str], exclude_built_in_templates: bool
-) -> List[Any]:
+    template_folder: str | None, exclude_built_in_templates: bool
+) -> list[Any]:
     """Load templates from the specified folder."""
     templates = []
     if template_folder:
@@ -328,9 +324,9 @@ def _load_templates(
 
 def _process_and_move_copy(
     filename: str,
-    res: Dict[str, Any],
-    copy: Optional[str],
-    move: Optional[str],
+    res: dict[str, Any],
+    copy: str | None,
+    move: str | None,
     filename_format: str,
 ) -> None:
     """Process the extracted data and copy/move the file."""

--- a/src/invoice2data/extract/invoice_template.py
+++ b/src/invoice2data/extract/invoice_template.py
@@ -5,11 +5,10 @@ Templates are initially read from .yml files and then kept as class.
 
 import re
 import unicodedata
+from collections import OrderedDict as OrderedDictType
 from logging import getLogger
 from pprint import pformat
 from typing import Any
-from typing import Dict
-from typing import OrderedDict as OrderedDictType
 
 import dateparser  # type: ignore[import-untyped]
 
@@ -68,7 +67,7 @@ class InvoiceTemplate(OrderedDictType[str, Any]):
         super().__init__(*args, **kwargs)
 
         # Merge template-specific options with defaults
-        self.options: Dict[str, Any] = OPTIONS_DEFAULT.copy()
+        self.options: dict[str, Any] = OPTIONS_DEFAULT.copy()
 
         if "options" in self:
             self.options.update(self["options"])
@@ -234,7 +233,7 @@ class InvoiceTemplate(OrderedDictType[str, Any]):
 
     def extract(
         self, optimized_str: str, invoice_file: str, input_module: Any
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Extracts data from the optimized string using the template.
 
         Args:
@@ -243,7 +242,7 @@ class InvoiceTemplate(OrderedDictType[str, Any]):
             input_module (Any): The input module used.
 
         Returns:
-            Dict[str, Any]: The extracted data.
+            dict[str, Any]: The extracted data.
 
         """
         output = _initialize_output_and_log(self, optimized_str)
@@ -274,7 +273,7 @@ class InvoiceTemplate(OrderedDictType[str, Any]):
 
 def _initialize_output_and_log(
     self: InvoiceTemplate, optimized_str: str
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Initialize the output dictionary and log debug information."""
     logger.debug("START optimized_str ========================\n" + optimized_str)
     logger.debug("END optimized_str ==========================")
@@ -296,7 +295,7 @@ def _initialize_output_and_log(
 
 def _handle_area(
     self: InvoiceTemplate,
-    v: Dict[str, Any],
+    v: dict[str, Any],
     input_module: Any,
     invoice_file: str,
     optimized_str: str,
@@ -317,9 +316,9 @@ def _handle_area(
 def _handle_parser(
     self: InvoiceTemplate,
     k: str,
-    v: Dict[str, Any],
+    v: dict[str, Any],
     optimized_str_for_parser: str,
-    output: Dict[str, Any],
+    output: dict[str, Any],
 ) -> None:
     """Handle parsing using different parsers."""
     if v["parser"] in PARSERS_MAPPING:
@@ -334,7 +333,7 @@ def _handle_parser(
 
 
 def _handle_legacy_syntax(
-    self: InvoiceTemplate, k: str, v: Any, optimized_str: str, output: Dict[str, Any]
+    self: InvoiceTemplate, k: str, v: Any, optimized_str: str, output: dict[str, Any]
 ) -> None:
     """Handle legacy syntax for backward compatibility."""
     result = None
@@ -361,8 +360,8 @@ def _handle_legacy_syntax(
 
 
 def _check_required_fields(
-    self: InvoiceTemplate, output: Dict[str, Any]
-) -> Dict[str, Any]:
+    self: InvoiceTemplate, output: dict[str, Any]
+) -> dict[str, Any]:
     """Check if all required fields are present in the output."""
     if "required_fields" not in self.keys():
         required_fields = ["date", "amount", "invoice_number", "issuer"]

--- a/src/invoice2data/extract/loader.py
+++ b/src/invoice2data/extract/loader.py
@@ -6,12 +6,9 @@ Templates are initially read from .yml or .json files and then kept as class.
 import codecs
 import json
 import os
+from collections.abc import Callable
 from logging import getLogger
 from typing import Any
-from typing import Callable
-from typing import Dict
-from typing import List
-from typing import Optional
 from typing import cast
 
 
@@ -32,7 +29,7 @@ logger = getLogger(__name__)
 
 def ordered_load(
     stream: str, loader: Callable[[str], Any] = json.loads
-) -> List[InvoiceTemplate]:
+) -> list[InvoiceTemplate]:
     """Loads a stream of JSON data.
 
     Args:
@@ -40,7 +37,7 @@ def ordered_load(
         loader (Callable[[str], Any], optional): JSON loader function. Defaults to json.loads.
 
     Returns:
-        List[InvoiceTemplate]: List of InvoiceTemplate objects.
+        list[InvoiceTemplate]: List of InvoiceTemplate objects.
     """
     output = []
 
@@ -54,22 +51,22 @@ def ordered_load(
     for tpl in tpl_stream:
         tpl = prepare_template(tpl)
         if tpl:
-            output.append(InvoiceTemplate(cast(Dict[str, Any], tpl)))
+            output.append(InvoiceTemplate(cast(dict[str, Any], tpl)))
 
     return output
 
 
-def read_templates(folder: Optional[str] = None) -> List[InvoiceTemplate]:
+def read_templates(folder: str | None = None) -> list[InvoiceTemplate]:
     """Load YAML templates from template folder. Return list of dicts.
 
     Use built-in templates if no folder is set.
 
     Args:
-        folder (Optional[str]): User-defined folder where templates are stored.
+        folder (str | None): User-defined folder where templates are stored.
                                 If None, uses built-in templates.
 
     Returns:
-        List[InvoiceTemplate]: List of InvoiceTemplate objects.
+        list[InvoiceTemplate]: List of InvoiceTemplate objects.
 
     Examples:
         >>> templates = read_templates("./src/invoice2data/extract/templates/au")
@@ -109,20 +106,20 @@ def read_templates(folder: Optional[str] = None) -> List[InvoiceTemplate]:
             tpl = prepare_template(tpl)
 
             if tpl:
-                output.append(InvoiceTemplate(cast(Dict[str, Any], tpl)))
+                output.append(InvoiceTemplate(cast(dict[str, Any], tpl)))
 
     logger.info("Loaded %d templates from %s", len(output), folder)
     return output
 
 
-def prepare_template(tpl: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+def prepare_template(tpl: dict[str, Any]) -> dict[str, Any] | None:
     """Prepare a template for use.
 
     Args:
-        tpl (Dict[str, Any]): Template dictionary.
+        tpl (dict[str, Any]): Template dictionary.
 
     Returns:
-        Optional[Dict[str, Any]]: Processed template dictionary.
+        dict[str, Any] | None: Processed template dictionary.
     """
     # Test if all required fields are in template
     if "keywords" not in tpl:

--- a/src/invoice2data/extract/parsers/lines.py
+++ b/src/invoice2data/extract/parsers/lines.py
@@ -5,12 +5,8 @@ Initial work and maintenance by Holger Brunn @hbrunn
 
 import re
 from logging import getLogger
+from re import Match
 from typing import Any
-from typing import Dict
-from typing import List
-from typing import Match
-from typing import Optional
-from typing import Union
 
 
 # from ..invoice_template import InvoiceTemplate  # type: ignore[unused-ignore]
@@ -20,7 +16,7 @@ logger = getLogger(__name__)
 DEFAULT_OPTIONS = {"line_separator": r"\n"}
 
 
-def parse_line(patterns: Union[str, List[str]], line: str) -> Optional[Match[str]]:
+def parse_line(patterns: str | list[str], line: str) -> Match[str] | None:
     """Parse a line using a given pattern or list of patterns.
 
     This function searches for a match in the given line using the provided
@@ -28,11 +24,11 @@ def parse_line(patterns: Union[str, List[str]], line: str) -> Optional[Match[str
     object; otherwise, it returns None.
 
     Args:
-        patterns (Union[str, List[str]]): The pattern(s) to search for.
+        patterns (str | list[str]): The pattern(s) to search for.
         line (str): The line to parse.
 
     Returns:
-        Optional[Match[str]]: A match object if a match is found, otherwise None.
+        Match[str] | None: A match object if a match is found, otherwise None.
     """
     patterns = patterns if isinstance(patterns, list) else [patterns]
     for pattern in patterns:
@@ -43,11 +39,11 @@ def parse_line(patterns: Union[str, List[str]], line: str) -> Optional[Match[str
 
 
 def parse_block(  # noqa: RUF100 C901
-    template: Dict[str, Any],
+    template: dict[str, Any],
     field: str,
-    settings: Dict[str, Any],
+    settings: dict[str, Any],
     content: str,
-) -> List[Dict[str, Any]]:
+) -> list[dict[str, Any]]:
     """Parse a block of lines to extract data.
 
     This function parses a block of lines from an invoice to extract data
@@ -56,13 +52,13 @@ def parse_block(  # noqa: RUF100 C901
     based on the configuration.
 
     Args:
-        template (Dict[str, Any]): The template containing extraction rules.
+        template (dict[str, Any]): The template containing extraction rules.
         field (str): The name of the field to extract.
-        settings (Dict[str, Any]): The settings for the extraction rule.
+        settings (dict[str, Any]): The settings for the extraction rule.
         content (str): The text content to parse.
 
     Returns:
-        List[Dict[str, Any]]: A list of dictionaries, where each dictionary
+        list[dict[str, Any]]: A list of dictionaries, where each dictionary
                                 represents an extracted row with field-value pairs.
     """
     # Validate settings
@@ -72,8 +68,8 @@ def parse_block(  # noqa: RUF100 C901
 
     logger.debug("START lines block content ========================\n%s", content)
     logger.debug("END lines block content ==========================")
-    lines: List[Dict[str, Any]] = []
-    current_row: Dict[str, Any] = {}
+    lines: list[dict[str, Any]] = []
+    current_row: dict[str, Any] = {}
 
     # We assume that structured line fields may either be individual lines or
     # they may be main line items with descriptions or details following beneath.
@@ -167,21 +163,21 @@ def parse_block(  # noqa: RUF100 C901
 
 
 def parse_by_rule(
-    template: Dict[str, Any],
+    template: dict[str, Any],
     field: str,
-    rule: Dict[str, Any],
+    rule: dict[str, Any],
     content: str,
-) -> List[Dict[str, Any]]:
+) -> list[dict[str, Any]]:
     """Parse lines from a block of text based on a rule.
 
     Args:
-        template (Dict[str, Any]): The template dictionary.
+        template (dict[str, Any]): The template dictionary.
         field (str): The field name.
-        rule (Dict[str, Any]): The rule dictionary.
+        rule (dict[str, Any]): The rule dictionary.
         content (str): The text content to parse.
 
     Returns:
-        List[Dict[str, Any]]: The parsed lines.
+        list[dict[str, Any]]: The parsed lines.
     """
     # First apply default options.
     settings = DEFAULT_OPTIONS.copy()
@@ -227,21 +223,21 @@ def parse_by_rule(
 
 
 def parse(
-    template: Dict[str, Any],
+    template: dict[str, Any],
     field: str,
-    settings: Dict[str, Any],
+    settings: dict[str, Any],
     content: str,
-) -> List[Dict[str, Any]]:
+) -> list[dict[str, Any]]:
     """Parse lines from the content based on the given settings.
 
     Args:
-        template (Dict[str, Any]): The template dictionary.
+        template (dict[str, Any]): The template dictionary.
         field (str): The field name.
-        settings (Dict[str, Any]): The settings dictionary.
+        settings (dict[str, Any]): The settings dictionary.
         content (str): The text content to parse.
 
     Returns:
-        List[Dict[str, Any]]: The parsed lines.
+        list[dict[str, Any]]: The parsed lines.
     """
     if "rules" in settings:
         # One field can have multiple sets of line-parsing rules
@@ -262,16 +258,16 @@ def parse(
 
 
 def parse_current_row(
-    match: Optional[Match[str]], current_row: Dict[str, Any]
-) -> Dict[str, Any]:
+    match: Match[str] | None, current_row: dict[str, Any]
+) -> dict[str, Any]:
     """Parse the current row data.
 
     Args:
-        match (Optional[Match[str]]): The match object.
-        current_row (Dict[str, Any]): The current row dictionary.
+        match (Match[str] | None): The match object.
+        current_row (dict[str, Any]): The current row dictionary.
 
     Returns:
-        Dict[str, Any]: The updated current row dictionary.
+        dict[str, Any]: The updated current row dictionary.
     """
     if match:
         for field, value in match.groupdict().items():

--- a/src/invoice2data/extract/parsers/regex.py
+++ b/src/invoice2data/extract/parsers/regex.py
@@ -15,9 +15,6 @@ import logging
 import re
 from collections import OrderedDict
 from typing import Any
-from typing import Dict
-from typing import List
-from typing import Optional
 
 from ..utils import _apply_grouping
 
@@ -28,7 +25,7 @@ logger = logging.getLogger(__name__)
 def parse(
     template: Any,
     field: str,
-    settings: Dict[str, Any],
+    settings: dict[str, Any],
     content: str,
     legacy: bool = False,
 ) -> Any:
@@ -37,7 +34,7 @@ def parse(
     Args:
         template (Any): The template object.
         field (str): The name of the field to extract.
-        settings (Dict[str, Any]): The settings for the field extraction.
+        settings (dict[str, Any]): The settings for the field extraction.
         content (str): The text content to parse.
         legacy (bool, optional): Whether to use legacy parsing. Defaults to False.
 
@@ -64,7 +61,7 @@ def parse(
     return result
 
 
-def _extract_matches(settings: Dict[str, Any], content: str) -> Optional[List[Any]]:
+def _extract_matches(settings: dict[str, Any], content: str) -> list[Any] | None:
     """Extract matches from the content using the given regexes."""
     if isinstance(settings["regex"], list):
         regexes = settings["regex"]
@@ -100,8 +97,8 @@ def _extract_matches(settings: Dict[str, Any], content: str) -> Optional[List[An
 
 
 def _apply_type_coercion(
-    template: Any, settings: Dict[str, Any], result: List[Any]
-) -> List[Any]:
+    template: Any, settings: dict[str, Any], result: list[Any]
+) -> list[Any]:
     """Apply type coercion to the extracted values."""
     if "type" in settings:
         for k, v in enumerate(result):
@@ -109,7 +106,7 @@ def _apply_type_coercion(
     return result
 
 
-def _remove_duplicates(legacy: bool, result: Optional[Any]) -> Optional[Any]:
+def _remove_duplicates(legacy: bool, result: Any | None) -> Any | None:
     """Remove duplicate values from the result."""
     if isinstance(result, list):
         if legacy:

--- a/src/invoice2data/extract/parsers/static.py
+++ b/src/invoice2data/extract/parsers/static.py
@@ -4,8 +4,6 @@
 
 from logging import getLogger
 from typing import Any
-from typing import Dict
-from typing import Optional
 
 
 logger = getLogger(__name__)
@@ -14,10 +12,10 @@ logger = getLogger(__name__)
 def parse(
     template: Any,
     field: str,
-    settings: Dict[str, Any],
+    settings: dict[str, Any],
     content: str,
     legacy: bool = False,
-) -> Optional[Any]:
+) -> Any | None:
     if "value" not in settings:
         logger.warning('Field "%s" doesn\'t have static value specified', field)
         return None

--- a/src/invoice2data/extract/plugins/lines.py
+++ b/src/invoice2data/extract/plugins/lines.py
@@ -7,13 +7,12 @@ only.
 
 from collections import OrderedDict
 from typing import Any
-from typing import Dict
 
 from .. import parsers
 
 
 def extract(
-    self: "OrderedDict[str, Any]", content: str, output: Dict[str, Any]
+    self: "OrderedDict[str, Any]", content: str, output: dict[str, Any]
 ) -> None:
     """Extract individual lines from an invoice.
 
@@ -24,7 +23,7 @@ def extract(
     Args:
         self (OrderedDict[str, Any]): The current instance of the class.
         content (str): The text content to parse.
-        output (Dict[str, Any]): A dictionary to store the extracted data.
+        output (dict[str, Any]): A dictionary to store the extracted data.
     """
     lines_data = parsers.lines.parse(self, "lines", self["lines"], content)
     if lines_data is not None:

--- a/src/invoice2data/extract/plugins/tables.py
+++ b/src/invoice2data/extract/plugins/tables.py
@@ -4,8 +4,6 @@ import re
 from collections import OrderedDict
 from logging import getLogger
 from typing import Any
-from typing import Dict
-from typing import Optional
 
 from ..utils import _apply_grouping
 
@@ -16,18 +14,18 @@ DEFAULT_OPTIONS = {"field_separator": r"\s+", "line_separator": r"\n"}
 
 
 def extract(
-    self: "OrderedDict[str, Any]", content: str, output: Dict[str, Any]
-) -> Optional[Dict[str, Any]]:
+    self: "OrderedDict[str, Any]", content: str, output: dict[str, Any]
+) -> dict[str, Any] | None:
     """Try to extract tables from an invoice.
 
     Args:
         self (InvoiceTemplate): The current instance of the class.  # noqa: DOC103
         content (str): The content of the invoice.
-        output (Dict[str, Any]): The updated output dictionary with extracted
+        output (dict[str, Any]): The updated output dictionary with extracted
                                     data or None if parsing fails.
 
     Returns:
-        Optional[List[Any]]: The extracted data as a list of dictionaries, or None if table parsing fails.
+        list[Any] | None: The extracted data as a list of dictionaries, or None if table parsing fails.
                                 Each dictionary represents a row in the table.
     """
     for i, table in enumerate(self["tables"]):
@@ -62,16 +60,16 @@ def extract(
 
 def _extract_and_validate_settings(
     self: "OrderedDict[str, Any]",
-    table: Dict[str, Any],
-) -> Optional[Dict[str, Any]]:
+    table: dict[str, Any],
+) -> dict[str, Any] | None:
     """Extract and validate table settings.
 
     Args:
         self (InvoiceTemplate): The current instance of the class.  # noqa: DOC103
-        table (Dict[str, Any]): A dictionary containing the table settings.
+        table (dict[str, Any]): A dictionary containing the table settings.
 
     Returns:
-        Optional[Dict[str, Any]]: The validated table settings, or None if
+        dict[str, Any] | None: The validated table settings, or None if
                                    validation fails.
     """
     plugin_settings = DEFAULT_OPTIONS.copy()
@@ -85,15 +83,15 @@ def _extract_and_validate_settings(
     return table
 
 
-def _extract_table_body(content: str, table: Dict[str, Any]) -> Optional[str]:
+def _extract_table_body(content: str, table: dict[str, Any]) -> str | None:
     """Extract the table body from the content.
 
     Args:
         content (str): The content of the invoice.
-        table (Dict[str, Any]): The validated table settings.
+        table (dict[str, Any]): The validated table settings.
 
     Returns:
-        Optional[str]: The extracted table body, or None if start or end
+        str | None: The extracted table body, or None if start or end
                        regexes are not found.
     """
     start = re.search(table["start"], content)
@@ -115,23 +113,23 @@ def _extract_table_body(content: str, table: Dict[str, Any]) -> Optional[str]:
 
 def _process_table_lines(
     self: "OrderedDict[str, Any]",
-    table: Dict[str, Any],
+    table: dict[str, Any],
     table_body: str,
-) -> Optional[Dict[str, Any]]:
+) -> dict[str, Any] | None:
     """Process the lines within the table body.
 
     Args:
         self (InvoiceTemplate): The current instance of the class.  # noqa: DOC103
-        table (Dict[str, Any]): The validated table settings.
+        table (dict[str, Any]): The validated table settings.
         table_body (str): The extracted table body.
 
     Returns:
-        List[Dict[str, Any]]: A list of dictionaries, where each dictionary
+        list[dict[str, Any]]: A list of dictionaries, where each dictionary
                               represents a row in the table.
     """
     types = table.get("types", {})
     no_match_found = True
-    line_output: Dict[str, Any] = {}
+    line_output: dict[str, Any] = {}
     for line in re.split(table["line_separator"], table_body):
         if not line.strip("").strip("\n") or line.isspace():
             continue
@@ -155,19 +153,19 @@ def _process_table_lines(
 
 def _process_table_line(  # noqa: C901
     self: "OrderedDict[str, Any]",
-    table: Dict[str, Any],
+    table: dict[str, Any],
     line: str,
-    types: Dict[str, Any],
-    output: Dict[str, Any],
+    types: dict[str, Any],
+    output: dict[str, Any],
 ) -> bool:
     """Process a single line within the table body.
 
     Args:
         self (InvoiceTemplate): The current instance of the class.
-        table (Dict[str, Any]): The validated table settings.
+        table (dict[str, Any]): The validated table settings.
         line (str): A single line from the table body.
-        types (Dict[str, Any]): A dictionary of type coercion rules.
-        output (Dict[str, Any]): A dictionary to store the extracted data.
+        types (dict[str, Any]): A dictionary of type coercion rules.
+        output (dict[str, Any]): A dictionary to store the extracted data.
 
     Returns:
         bool: True if processing is successful, False if date parsing fails.

--- a/src/invoice2data/extract/utils.py
+++ b/src/invoice2data/extract/utils.py
@@ -2,14 +2,12 @@
 
 from logging import getLogger
 from typing import Any
-from typing import Dict
-from typing import Optional
 
 
 logger = getLogger(__name__)
 
 
-def _apply_grouping(settings: Dict[str, Any], result: Any) -> Optional[Any]:
+def _apply_grouping(settings: dict[str, Any], result: Any) -> Any | None:
     """Apply grouping to the extracted values."""
     if "group" in settings:
         result = list(filter(None, result))

--- a/src/invoice2data/input/gvision.py
+++ b/src/invoice2data/input/gvision.py
@@ -2,7 +2,6 @@
 
 import logging
 import os
-from typing import Optional
 
 
 logger = logging.getLogger(__name__)
@@ -22,7 +21,7 @@ def have_google_cloud() -> bool:
     return GOOGLE_CLOUD_AVAILABLE
 
 
-def to_text(path: str, bucket_name: Optional[str] = None, language: str = "en") -> str:
+def to_text(path: str, bucket_name: str | None = None, language: str = "en") -> str:
     """Sends PDF files to Google Cloud Vision for OCR.
 
     Before using invoice2data, make sure you have the auth JSON path set as
@@ -30,7 +29,7 @@ def to_text(path: str, bucket_name: Optional[str] = None, language: str = "en") 
 
     Args:
         path (str): Path of the electronic invoice in JPG or PNG format.
-        bucket_name (Optional[str]): Name of the bucket to use for file storage
+        bucket_name (str | None): Name of the bucket to use for file storage
                                      and results cache. Defaults to "cloud-vision-84893".
         language (str, optional): Language to use for OCR. Defaults to "en".
 

--- a/src/invoice2data/input/ocrmypdf.py
+++ b/src/invoice2data/input/ocrmypdf.py
@@ -4,8 +4,6 @@ import logging
 import tempfile
 from pathlib import Path
 from typing import Any
-from typing import Dict
-from typing import Optional
 
 from . import pdftotext
 
@@ -37,8 +35,8 @@ OPTIONS_DEFAULT = {
 
 def to_text(
     path: str,
-    area_details: Optional[Dict[str, Any]] = None,
-    input_reader_config: Optional[Dict[str, Any]] = None,
+    area_details: dict[str, Any] | None = None,
+    input_reader_config: dict[str, Any] | None = None,
 ) -> str:
     """Pre-processes PDF files with ocrmypdf before PDFtotext parsing.
 
@@ -47,8 +45,8 @@ def to_text(
 
     Args:
         path (str): Path to the PDF invoice file.
-        area_details (Optional[Dict[str, Any]], optional): Details about the area to extract. Defaults to None.
-        input_reader_config (Optional[Dict[str, Any]], optional): Configuration settings for the input reader. Defaults to None.
+        area_details (dict[str, Any] | None, optional): Details about the area to extract. Defaults to None.
+        input_reader_config (dict[str, Any] | None, optional): Configuration settings for the input reader. Defaults to None.
 
     Returns:
         str: Extracted text from the PDF, or an empty string if OCRmyPDF is not available or processing fails.
@@ -71,9 +69,7 @@ def to_text(
         return ""
 
 
-def pre_process_pdf(
-    path: str, pre_conf: Optional[Dict[str, Any]] = None
-) -> Optional[str]:
+def pre_process_pdf(path: str, pre_conf: dict[str, Any] | None = None) -> str | None:
     """Pre-processes PDF files with ocrmypdf before PDFtotext parsing.
 
     Uses a temporary file for the output by default.
@@ -81,10 +77,10 @@ def pre_process_pdf(
 
     Args:
         path (str): Path to the PDF invoice file.
-        pre_conf (Optional[Dict[str, Any]], optional): Configuration settings for ocrmypdf. Defaults to None.
+        pre_conf (dict[str, Any] | None, optional): Configuration settings for ocrmypdf. Defaults to None.
 
     Returns:
-        Optional[str]: Path to the processed PDF file, or None if processing fails.
+        str | None: Path to the processed PDF file, or None if processing fails.
     """
     if not ocrmypdf_available():
         logger.warning("ocrmypdf is not available. Install with 'pip install ocrmypdf'")

--- a/src/invoice2data/input/pdfminer_wrapper.py
+++ b/src/invoice2data/input/pdfminer_wrapper.py
@@ -2,16 +2,14 @@
 
 from io import StringIO
 from typing import Any
-from typing import Dict
-from typing import Set
 
 
-def to_text(path: str, **kwargs: Dict[str, Any]) -> str:
+def to_text(path: str, **kwargs: dict[str, Any]) -> str:
     """Wrapper around `pdfminer` to extract text from PDF.
 
     Args:
         path (str): Path to the PDF file.
-        **kwargs (Dict[str, Any]): Keyword arguments to be passed to `pdfminer`.
+        **kwargs (dict[str, Any]): Keyword arguments to be passed to `pdfminer`.
 
     Returns:
         str: Extracted text from the PDF.
@@ -32,7 +30,7 @@ def to_text(path: str, **kwargs: Dict[str, Any]) -> str:
         password = ""
         maxpages = 0
         caching = True
-        pagenos: Set[int] = set()
+        pagenos: set[int] = set()
         pages = PDFPage.get_pages(
             fp,
             pagenos,

--- a/src/invoice2data/input/pdfplumber.py
+++ b/src/invoice2data/input/pdfplumber.py
@@ -2,19 +2,17 @@
 
 from logging import getLogger
 from typing import Any
-from typing import Dict
-from typing import List
 
 
 logger = getLogger(__name__)
 
 
-def to_text(path: str, **kwargs: Dict[str, Any]) -> str:
+def to_text(path: str, **kwargs: dict[str, Any]) -> str:
     """Extract text from PDF using pdfplumber.
 
     Args:
         path (str): Path to the PDF file.
-        **kwargs (Dict[str, Any]): Keyword arguments to be passed to `pdfplumber`.
+        **kwargs (dict[str, Any]): Keyword arguments to be passed to `pdfplumber`.
 
     Returns:
         str: Extracted text from the PDF.
@@ -50,11 +48,11 @@ def to_text(path: str, **kwargs: Dict[str, Any]) -> str:
     return raw_text
 
 
-def res_to_raw_text(res: List[Dict[str, Any]]) -> str:
+def res_to_raw_text(res: list[dict[str, Any]]) -> str:
     """Extract raw text from pdfplumber result.
 
     Args:
-        res (List[Dict[str, Any]]): Result from pdfplumber.
+        res (list[dict[str, Any]]): Result from pdfplumber.
 
     Returns:
         str: The raw text extracted from the result.

--- a/src/invoice2data/input/pdftotext.py
+++ b/src/invoice2data/input/pdftotext.py
@@ -2,16 +2,14 @@
 
 import os
 from typing import Any
-from typing import Dict
-from typing import Optional
 
 
-def to_text(path: str, area_details: Optional[Dict[str, Any]] = None) -> str:
+def to_text(path: str, area_details: dict[str, Any] | None = None) -> str:
     """Extract text from a PDF file using pdftotext.
 
     Args:
         path (str): Path to the PDF file.
-        area_details (Optional[Dict[str, Any]], optional):
+        area_details (dict[str, Any] | None, optional):
             Specific area in the PDF to extract text from.
             Defaults to None (extract from the entire page).
             If provided, should be a dictionary with the following keys:

--- a/src/invoice2data/input/tesseract.py
+++ b/src/invoice2data/input/tesseract.py
@@ -13,20 +13,17 @@ from subprocess import Popen
 from subprocess import TimeoutExpired
 from subprocess import run
 from typing import Any
-from typing import Dict
-from typing import Optional
-from typing import Set
 
 
 logger = getLogger(__name__)
 
 
-def to_text(path: str, area_details: Optional[Dict[str, Any]] = None) -> str:
+def to_text(path: str, area_details: dict[str, Any] | None = None) -> str:
     """Extract text from image using tesseract OCR.
 
     Args:
         path (str): Path to the image file.
-        area_details (Optional[Dict[str, Any]], optional):
+        area_details (dict[str, Any] | None, optional):
             Specific area in the image to extract text from.
             Defaults to None (extract from the entire image).
 
@@ -187,5 +184,5 @@ def get_languages() -> str:
         if line.startswith("Error"):
             raise OSError(lang_error(output))
     _header, *rest = output.splitlines()
-    langlist: Set[str] = {lang.strip() for lang in rest}
+    langlist: set[str] = {lang.strip() for lang in rest}
     return "+".join(map(str, langlist))

--- a/src/invoice2data/output/to_csv.py
+++ b/src/invoice2data/output/to_csv.py
@@ -3,12 +3,10 @@
 import csv
 import datetime  # noqa
 from typing import Any
-from typing import Dict
-from typing import List
 
 
 def write_to_file(
-    data: List[Dict[str, Any]], path: str, date_format: str = "%Y-%m-%d"
+    data: list[dict[str, Any]], path: str, date_format: str = "%Y-%m-%d"
 ) -> None:
     """Export extracted fields to CSV.
 
@@ -16,7 +14,7 @@ def write_to_file(
     directory, otherwise in the current directory.
 
     Args:
-        data (List[Dict[str, Any]]): A list of dictionaries of extracted fields. If only a
+        data (list[dict[str, Any]]): A list of dictionaries of extracted fields. If only a
                             single file was processed, it must be passed as a
                             single-element list.
         path (str): CSV file to save output to.

--- a/src/invoice2data/output/to_json.py
+++ b/src/invoice2data/output/to_json.py
@@ -3,8 +3,6 @@
 import datetime
 import json
 from typing import Any
-from typing import Dict
-from typing import List
 
 
 def format_item(item: Any, date_format: str) -> Any:
@@ -19,7 +17,7 @@ def format_item(item: Any, date_format: str) -> Any:
     """
     if isinstance(item, datetime.date):
         return item.strftime(date_format)
-    if isinstance(item, (dict, list)):
+    if isinstance(item, dict | list):
         iter_obj = item.items() if isinstance(item, dict) else enumerate(item)
         for k, v in iter_obj:
             item[k] = format_item(v, date_format)
@@ -27,7 +25,7 @@ def format_item(item: Any, date_format: str) -> Any:
 
 
 def write_to_file(
-    data: List[Dict[str, Any]], path: str, date_format: str = "%Y-%m-%d"
+    data: list[dict[str, Any]], path: str, date_format: str = "%Y-%m-%d"
 ) -> None:
     """Export extracted fields to JSON.
 
@@ -35,7 +33,7 @@ def write_to_file(
     the specified directory, otherwise in the current directory.
 
     Args:
-        data (List[Dict[str, Any]]): Dictionary of extracted fields.
+        data (list[dict[str, Any]]): Dictionary of extracted fields.
         path (str): Directory to save the generated JSON file.
         date_format (str): Date format used in the generated file.
                             Defaults to "%Y-%m-%d".

--- a/src/invoice2data/output/to_xml.py
+++ b/src/invoice2data/output/to_xml.py
@@ -3,8 +3,6 @@
 import datetime
 import importlib.util
 from typing import Any
-from typing import Dict
-from typing import List
 from xml.etree import ElementTree
 
 
@@ -37,7 +35,7 @@ def prettify(elem: ElementTree.Element) -> Any:
 
 
 def dict_to_tags(
-    parent: ElementTree.Element, data: Dict[str, Any], date_format: str
+    parent: ElementTree.Element, data: dict[str, Any], date_format: str
 ) -> None:
     """Convert a dictionary to XML tags.
 
@@ -47,14 +45,14 @@ def dict_to_tags(
 
     Args:
         parent (ElementTree.Element): The parent element.
-        data (Dict[str, Any]): The dictionary to be converted.
+        data (dict[str, Any]): The dictionary to be converted.
         date_format (str): The date format to use.
     """
     for k, v in data.items():
         tag = ElementTree.SubElement(parent, k)
         if isinstance(v, str):
             tag.text = v
-        elif isinstance(v, (int, float)):
+        elif isinstance(v, int | float):
             tag.text = str(v)
         elif isinstance(v, datetime.date):
             tag.text = v.strftime(date_format)
@@ -65,7 +63,7 @@ def dict_to_tags(
 
 
 def write_to_file(
-    data: List[Dict[str, Any]], path: str, date_format: str = "%Y-%m-%d"
+    data: list[dict[str, Any]], path: str, date_format: str = "%Y-%m-%d"
 ) -> None:
     """Export extracted fields to xml.
 
@@ -73,7 +71,7 @@ def write_to_file(
     if not then in root.
 
     Args:
-        data (List[Dict[str, Any]]): List of dictionaries containing extracted fields.
+        data (list[dict[str, Any]]): List of dictionaries containing extracted fields.
         path (str): Path to save the generated XML file.
         date_format (str, optional): Date format used in generated file.
             Defaults to "%Y-%m-%d".

--- a/tests/common.py
+++ b/tests/common.py
@@ -2,14 +2,13 @@
 
 import logging
 import os
-from typing import List
 
 
 # Reduce log level of various modules
 logging.getLogger("pdfminer").setLevel(logging.WARNING)
 
 
-def get_sample_files(extension: str, exclude_input_specific: bool = True) -> List[str]:
+def get_sample_files(extension: str, exclude_input_specific: bool = True) -> list[str]:
     """Get the  sample files.
 
     Args:
@@ -30,7 +29,7 @@ def get_sample_files(extension: str, exclude_input_specific: bool = True) -> Lis
     return compare_files
 
 
-def exclude_template(test_list: List[str], exclude_list: List[str]) -> List[str]:
+def exclude_template(test_list: list[str], exclude_list: list[str]) -> list[str]:
     """Exclude specific templates from the list.
 
     Args:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,7 +5,6 @@ import os
 import shutil
 import unittest
 from typing import Any
-from typing import Dict
 from xml.dom import minidom
 
 from invoice2data.__main__ import main  # Import main only
@@ -243,7 +242,7 @@ class TestCLI(unittest.TestCase):
         self.assertEqual(cm.exception.code, 0)
         shutil.rmtree(directory, ignore_errors=True)
 
-    def get_filename_format_test_data(self, filename_format: str) -> Dict[str, Any]:
+    def get_filename_format_test_data(self, filename_format: str) -> dict[str, Any]:
         """Generates test input and expected output by walking the compare dir.
 
         Args:
@@ -252,7 +251,7 @@ class TestCLI(unittest.TestCase):
         Returns:
             Dict[str, Any]: A dictionary of test data.
         """
-        data: Dict[str, Any] = {}
+        data: dict[str, Any] = {}
         compare_folder = os.path.dirname("tests/compare/")
         for path, _subdirs, files in os.walk(compare_folder):
             for file in files:
@@ -286,7 +285,7 @@ class TestCLI(unittest.TestCase):
         shutil.rmtree(os.path.dirname(copy_dir), ignore_errors=True)
         filename_format = "{date} {invoice_number} {desc}.pdf"
 
-        data: Dict[str, Any] = self.get_filename_format_test_data(filename_format)
+        data: dict[str, Any] = self.get_filename_format_test_data(filename_format)
 
         os.makedirs(copy_dir)
 
@@ -316,7 +315,7 @@ class TestCLI(unittest.TestCase):
         copy_dir = os.path.join("tests", "copy_test", "pdf")
         filename_format = "Custom Prefix {date} {invoice_number}.pdf"
 
-        data: Dict[str, Any] = self.get_filename_format_test_data(filename_format)
+        data: dict[str, Any] = self.get_filename_format_test_data(filename_format)
 
         os.makedirs(copy_dir)
 

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -14,7 +14,6 @@ import json
 import os
 import unittest
 from pathlib import Path
-from typing import Union
 
 from invoice2data.__main__ import extract_data
 from invoice2data.extract.loader import read_templates
@@ -25,7 +24,7 @@ class TestExtraction(unittest.TestCase):
         self.templates = read_templates()
 
     def _run_test_on_folder(
-        self, folder: Union[str, Path]
+        self, folder: str | Path
     ) -> None:  # Use Union for Python < 3.10
         for path, _subdirs, files in os.walk(folder):
             for f in files:

--- a/tests/test_invoice_template.py
+++ b/tests/test_invoice_template.py
@@ -1,7 +1,5 @@
 import unittest
 from typing import Any
-from typing import Dict
-from typing import List
 
 from invoice2data.extract.invoice_template import InvoiceTemplate
 
@@ -22,7 +20,7 @@ def test_template_with_exclude_keyword_is_not_matched() -> None:
 
 
 def test_skip_template_with_too_long_lang_code() -> None:
-    options_test: Dict[str, List[str]] = {
+    options_test: dict[str, list[str]] = {
         "currency": ["EUR"],
         "date_formats": [],
         "languages": ["aaa"],
@@ -30,7 +28,7 @@ def test_skip_template_with_too_long_lang_code() -> None:
         "replace": [],
     }
 
-    tpl: Dict[str, Any] = {}
+    tpl: dict[str, Any] = {}
     tpl["keywords"] = ["Basic Test"]
     tpl["exclude_keywords"] = []
     tpl["options"] = options_test
@@ -49,7 +47,7 @@ def test_skip_template_with_too_long_lang_code() -> None:
 
 class TestInvoiceTemplateMethods(unittest.TestCase):
     def test_replace_a_with_b(self) -> None:
-        options_test: Dict[str, Any] = {
+        options_test: dict[str, Any] = {
             "currency": ["EUR"],
             "date_formats": [],
             "languages": ["aa"],
@@ -57,7 +55,7 @@ class TestInvoiceTemplateMethods(unittest.TestCase):
             "replace": [["a", "b"]],
         }
 
-        tpl: Dict[str, Any] = {}
+        tpl: dict[str, Any] = {}
         tpl["keywords"] = ["Basic Test"]
         tpl["exclude_keywords"] = []
         tpl["options"] = options_test
@@ -72,7 +70,7 @@ class TestInvoiceTemplateMethods(unittest.TestCase):
         self.assertEqual(optimized_str, "b")
 
     def test_remove_accents(self) -> None:
-        options_test: Dict[str, Any] = {
+        options_test: dict[str, Any] = {
             "currency": ["EUR"],
             "date_formats": [],
             "languages": ["aa"],
@@ -80,7 +78,7 @@ class TestInvoiceTemplateMethods(unittest.TestCase):
             "remove_accents": True,
         }
 
-        tpl: Dict[str, Any] = {}
+        tpl: dict[str, Any] = {}
         tpl["keywords"] = ["Basic Test"]
         tpl["exclude_keywords"] = []
         tpl["options"] = options_test
@@ -99,7 +97,7 @@ class TestInvoiceTemplateMethods(unittest.TestCase):
         )
 
     def test_remove_whitespace(self) -> None:
-        options_test: Dict[str, Any] = {
+        options_test: dict[str, Any] = {
             "currency": ["EUR"],
             "date_formats": [],
             "languages": ["aa"],
@@ -107,7 +105,7 @@ class TestInvoiceTemplateMethods(unittest.TestCase):
             "remove_whitespace": True,
         }
 
-        tpl: Dict[str, Any] = {}
+        tpl: dict[str, Any] = {}
         tpl["keywords"] = ["Basic Test"]
         tpl["exclude_keywords"] = []
         tpl["options"] = options_test
@@ -122,7 +120,7 @@ class TestInvoiceTemplateMethods(unittest.TestCase):
         self.assertEqual(optimized_str, "ab", "remove whitespace test failed")
 
     def test_lowercase(self) -> None:
-        options_test: Dict[str, Any] = {
+        options_test: dict[str, Any] = {
             "currency": ["EUR"],
             "date_formats": [],
             "languages": ["aa"],
@@ -130,7 +128,7 @@ class TestInvoiceTemplateMethods(unittest.TestCase):
             "lowercase": True,
         }
 
-        tpl: Dict[str, Any] = {}
+        tpl: dict[str, Any] = {}
         tpl["keywords"] = ["Basic Test"]
         tpl["exclude_keywords"] = []
         tpl["options"] = options_test

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -15,9 +15,6 @@ import shutil
 import unittest
 from io import StringIO  # noqa: F401
 from typing import Any
-from typing import Dict
-from typing import List
-from typing import Union
 from unittest import mock
 
 from invoice2data.__main__ import extract_data
@@ -46,7 +43,7 @@ needs_pdfplumber = unittest.skipIf(
 )
 
 
-def _extract_data_for_export() -> List[Dict[str, Any]]:
+def _extract_data_for_export() -> list[dict[str, Any]]:
     pdf_files = get_sample_files(".pdf")
     for file in pdf_files:
         if file.endswith("oyo.pdf"):
@@ -108,7 +105,7 @@ class TestLIB(unittest.TestCase):
             if file.endswith("NetpresseInvoice.pdf"):
                 print("Testing pdfminer with file", file)
                 try:
-                    res: Union[str, Dict[str, Any]] = extract_data(
+                    res: str | dict[str, Any] = extract_data(
                         file, None, pdfminer_wrapper
                     )
                     print(res)

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,8 +1,8 @@
 import os
 import shutil
 import unittest
+from collections.abc import Generator
 from pathlib import Path
-from typing import Generator
 
 import pytest
 


### PR DESCRIPTION
Now that \`requires-python\` is \`>=3.10\` (after the dependency sweep dropped EOL 3.8/3.9), this modernizes the type hints to the builtin-generic / union syntax and re-enables the ruff rules that were temporarily deferred.

## What
- `typing.List/Dict/Tuple` → builtin `list/dict/tuple` (PEP 585, ruff UP006/UP035)
- `Optional[X]` / `Union[X, Y]` → `X | None` / `X | Y` (PEP 604, ruff UP007)
- `isinstance(x, (A, B))` → `isinstance(x, A | B)` (UP038)
- `typing.Match` → `re.Match`
- Docstring `Args:`/`Returns:` type references updated to match the new signatures
- Removed the temporary `UP006/UP007/UP035/UP038` ignores from `[tool.ruff.lint]`

## Why
These rules fire repo-wide once the floor is 3.10; they were ignored during the security sweep to keep that change focused. This is the dedicated follow-up.

## Scope / safety
Signatures + docstrings only — **no runtime or behaviour changes**. Annotations evaluate fine at runtime on 3.10+.

## Verified
- `ruff check` + `ruff format --check`: clean
- `pydoclint src`: no violations
- `pytest`: 43 passed, 3 skipped
- `xdoctest`: 5/5
- HTML + LaTeX docs build: ok

Mechanical change applied via `ruff --fix` for code plus matching docstring updates.