### PR TITLE
fix(output): emit a single CSV header row across all invoices

### DIFF
--- a/src/invoice2data/output/to_csv.py
+++ b/src/invoice2data/output/to_csv.py
@@ -31,6 +31,23 @@ def _cell(value: Any, date_format: str) -> Any:
     return value
 
 
+def _merge_keys(key_lists: Any) -> list[str]:
+    """Return the ordered union of several key sequences, without duplicates.
+
+    Args:
+        key_lists (Any): An iterable of key sequences.
+
+    Returns:
+        list[str]: Every key seen, in first-seen order.
+    """
+    merged: list[str] = []
+    for keys in key_lists:
+        for key in keys:
+            if key not in merged:
+                merged.append(key)
+    return merged
+
+
 def _write_flat(writer: Any, data: list[dict[str, Any]], date_format: str) -> None:
     """Write one row per invoice; list/dict fields are JSON-encoded.
 
@@ -39,13 +56,12 @@ def _write_flat(writer: Any, data: list[dict[str, Any]], date_format: str) -> No
         data (list[dict[str, Any]]): The extracted invoices.
         date_format (str): strftime format used for dates.
     """
-    last_header = None
+    header = _merge_keys(invoice.keys() for invoice in data)
+    if not header:
+        return
+    writer.writerow(header)
     for invoice in data:
-        header = list(invoice.keys())
-        if header != last_header:
-            writer.writerow(header)
-            last_header = header
-        writer.writerow([_cell(value, date_format) for value in invoice.values()])
+        writer.writerow([_cell(invoice.get(key, ""), date_format) for key in header])
 
 
 def _write_exploded(writer: Any, data: list[dict[str, Any]], date_format: str) -> None:
@@ -59,21 +75,20 @@ def _write_exploded(writer: Any, data: list[dict[str, Any]], date_format: str) -
         data (list[dict[str, Any]]): The extracted invoices.
         date_format (str): strftime format used for dates.
     """
-    last_header = None
+    scalar_keys = _merge_keys(
+        [key for key in invoice if key != "lines"] for invoice in data
+    )
+    line_keys = _merge_keys(
+        item.keys() for invoice in data for item in (invoice.get("lines") or [])
+    )
+    header = scalar_keys + [f"line_{key}" for key in line_keys]
+    if not header:
+        return
+    writer.writerow(header)
     for invoice in data:
-        scalars = {key: value for key, value in invoice.items() if key != "lines"}
         line_items = invoice.get("lines") or [{}]
-        line_keys: list[str] = []
         for item in line_items:
-            for key in item:
-                if key not in line_keys:
-                    line_keys.append(key)
-        header = list(scalars.keys()) + [f"line_{key}" for key in line_keys]
-        for item in line_items:
-            if header != last_header:
-                writer.writerow(header)
-                last_header = header
-            row = [_cell(value, date_format) for value in scalars.values()]
+            row = [_cell(invoice.get(key, ""), date_format) for key in scalar_keys]
             row += [_cell(item.get(key, ""), date_format) for key in line_keys]
             writer.writerow(row)
 

--- a/tests/test_csv_output.py
+++ b/tests/test_csv_output.py
@@ -47,3 +47,35 @@ def test_csv_explode_mode_one_row_per_line(tmp_path: Path) -> None:
     assert rows[1][header.index("line_name")] == "Widget"
     assert rows[2][header.index("line_name")] == "Gadget"
     assert rows[1][header.index("invoice_number")] == "INV1"  # repeated per line
+
+
+def test_csv_single_header_when_fields_missing(tmp_path: Path) -> None:
+    """A missing field must not restart the CSV with a new header row (#599)."""
+    data = [
+        {"invoice_number": "INV1", "amount": 1.0, "vat": "NL1"},
+        {"invoice_number": "INV2", "amount": 2.0},
+        {"invoice_number": "INV3", "amount": 3.0, "vat": "NL3"},
+    ]
+    out = str(tmp_path / "out.csv")
+    to_csv.write_to_file(data, out)
+    rows = _read_csv(out)
+    header = rows[0]
+    assert header == ["invoice_number", "amount", "vat"]
+    assert len(rows) == 4  # one header + one row per invoice
+    assert all(len(row) == len(header) for row in rows)
+    assert rows[2] == ["INV2", "2.0", ""]  # missing field is an empty cell
+
+
+def test_csv_explode_single_header_when_fields_missing(tmp_path: Path) -> None:
+    """Explode mode must also emit exactly one header row (#599)."""
+    data = [
+        {"invoice_number": "INV1", "lines": [{"name": "Widget", "qty": 2.0}]},
+        {"invoice_number": "INV2", "lines": [{"name": "Gadget"}]},
+    ]
+    out = str(tmp_path / "out.csv")
+    to_csv.write_to_file(data, out, lines_mode="explode")
+    rows = _read_csv(out)
+    header = rows[0]
+    assert header == ["invoice_number", "line_name", "line_qty"]
+    assert len(rows) == 3  # one header + one row per line item
+    assert rows[2] == ["INV2", "Gadget", ""]


### PR DESCRIPTION
Closes #599

Exporting several invoices to CSV wrote a new header row whenever an invoice was missing a field, because `_write_flat` compared each invoice's own key list to the previous one. That produced the interleaved header rows and ragged row widths reported in the issue.

Both writers now compute the ordered union of all keys up front, write exactly one header, and leave an empty cell for absent fields. The `explode` line-item writer had the same defect and is fixed too. Two regression tests fail on master and pass with the change.
