### PR TITLE
fix(loader): skip empty template files instead of crashing (#721)

### DIFF
--- a/src/invoice2data/extract/loader.py
+++ b/src/invoice2data/extract/loader.py
@@ -110,6 +110,9 @@ def read_templates(folder: str | None = None) -> list[InvoiceTemplate]:
                         continue
                 else:
                     continue
+            if tpl is None:
+                logger.warning("Skipping empty template: %s", name)
+                continue
             tpl["template_name"] = name
             tpl = prepare_template(tpl)
 

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -122,6 +122,23 @@ def test_template_with_missing_keywords_is_not_loaded(
     assert templates == []
 
 
+def test_empty_template_is_skipped(
+    templatedirectory: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Issue #721: an empty template file used to crash with
+    ``TypeError: 'NoneType' object does not support item assignment``.
+    """
+    (templatedirectory / "empty.yaml").write_text("", encoding="utf-8")
+    (templatedirectory / "null.json").write_text("null", encoding="utf-8")
+
+    with caplog.at_level("WARNING"):
+        templates = read_templates(str(templatedirectory))
+
+    assert templates == []
+    assert "Skipping empty template: empty.yaml" in caplog.text
+    assert "Skipping empty template: null.json" in caplog.text
+
+
 def test_template_name_is_yaml_filename(templatedirectory: Path) -> None:
     yamlfile = templatedirectory / "thisnameisimportant.yml"
     yamlfile.write_text(template_with_single_special_char, encoding="utf-8")

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -122,21 +122,40 @@ def test_template_with_missing_keywords_is_not_loaded(
     assert templates == []
 
 
-def test_empty_template_is_skipped(
+def test_empty_yaml_template_is_skipped(
     templatedirectory: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Issue #721: an empty template file used to crash with
-    ``TypeError: 'NoneType' object does not support item assignment``.
+    """Issue #721: an empty YAML template must not crash the loader.
+
+    ``yaml.safe_load('')`` returns ``None`` and the loader then did
+    ``tpl["template_name"] = name`` -> ``TypeError: 'NoneType' object does
+    not support item assignment``. Now guarded with a None-check + warning.
     """
     (templatedirectory / "empty.yaml").write_text("", encoding="utf-8")
-    (templatedirectory / "null.json").write_text("null", encoding="utf-8")
 
     with caplog.at_level("WARNING"):
         templates = read_templates(str(templatedirectory))
 
     assert templates == []
     assert "Skipping empty template: empty.yaml" in caplog.text
-    assert "Skipping empty template: null.json" in caplog.text
+
+
+def test_empty_json_template_is_skipped(
+    templatedirectory: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """An empty ``.json`` file goes through a different path than empty YAML.
+
+    ``json.loads('')`` raises ``ValueError``, which the loader already caught
+    and warned about pre-#721. Kept as a separate test so a future JSON-loader
+    refactor can't quietly regress the empty-file case there either.
+    """
+    (templatedirectory / "empty.json").write_text("", encoding="utf-8")
+
+    with caplog.at_level("WARNING"):
+        templates = read_templates(str(templatedirectory))
+
+    assert templates == []
+    assert "empty.json" in caplog.text
 
 
 def test_template_name_is_yaml_filename(templatedirectory: Path) -> None:


### PR DESCRIPTION
## Summary

- Empty `.yaml` / `null` `.json` template files no longer crash `read_templates()` with `TypeError: 'NoneType' object does not support item assignment`.
- The loader logs a warning naming the offending file and continues with the rest of the directory.

Closes #721.

## Repro (from the issue)

```py
mkdir demo_templates && touch demo_templates/empty_template.yaml
python -c "from invoice2data.extract.loader import read_templates; read_templates('demo_templates')"
# TypeError: 'NoneType' object does not support item assignment
```

`yaml.safe_load('')` returns `None`, but the next line assumes a dict and assigns `tpl["template_name"] = name`. One empty placeholder took the whole directory down.

## Test plan

- [x] `pytest tests/test_loader.py` — all 12 passing including the new `test_empty_template_is_skipped` (covers both `.yaml` and `.json` empty cases + asserts the warning is logged)