### PR TITLE
fix(extract): preserve extracted currency (setdefault vs clobber)

### DIFF
--- a/src/invoice2data/extract/invoice_template.py
+++ b/src/invoice2data/extract/invoice_template.py
@@ -262,7 +262,11 @@ class InvoiceTemplate(OrderedDictType[str, Any]):
 
             else:
                 _handle_legacy_syntax(self, k, v, optimized_str, output)
-        output["currency"] = self.options["currency"]
+        # Fall back to the template's `options.currency` only when no field
+        # extracted a currency. Prior versions unconditionally overwrote the
+        # captured value with the option (default "EUR"), silently defeating
+        # dynamic currency extraction; use setdefault to preserve it.
+        output.setdefault("currency", self.options["currency"])
 
         # Run plugins (invoice_file is needed by path-based plugins like camelot):
         for plugin_keyword, plugin_func in PLUGIN_MAPPING.items():

--- a/tests/test_invoice_template.py
+++ b/tests/test_invoice_template.py
@@ -143,5 +143,64 @@ class TestInvoiceTemplateMethods(unittest.TestCase):
         self.assertEqual(optimized_str, "abcd", "Lowercase test failed")
 
 
+def _currency_template(fields: dict[str, Any], name: str) -> InvoiceTemplate:
+    """Build an InvoiceTemplate with the four required fields stubbed in."""
+    base_fields: dict[str, Any] = {
+        "issuer": "Any Vendor Ltd",
+        "date": {"parser": "regex", "regex": r"Date:\s+(\S+)", "type": "date"},
+        "amount": {"parser": "regex", "regex": r"Total:\s+([\d.]+)", "type": "float"},
+        "invoice_number": {"parser": "regex", "regex": r"Invoice #(\d+)"},
+        **fields,
+    }
+    tpl: dict[str, Any] = {
+        "keywords": ["Any Vendor Ltd"],
+        "exclude_keywords": [],
+        "options": {
+            "currency": "EUR",
+            "date_formats": [],
+            "languages": ["en"],
+            "decimal_separator": ".",
+            "replace": [],
+        },
+        "template_name": name,
+        "fields": base_fields,
+    }
+    return InvoiceTemplate(tpl)
+
+
+def test_extracted_currency_survives_extract() -> None:
+    """Regression: dynamic currency extraction must not be clobbered.
+
+    ``output["currency"] = self.options["currency"]`` used to unconditionally
+    overwrite any currency captured by a template field with the template's
+    static option (default "EUR"), silently defeating dynamic currency
+    extraction. ``setdefault`` now preserves the extracted value.
+    """
+    tpl = _currency_template(
+        {"currency": {"parser": "regex", "regex": r"Currency:\s+(\w{3})"}},
+        "currency_capture.yml",
+    )
+    extracted = tpl.extract(
+        "Any Vendor Ltd\nInvoice #42\nDate: 2026-01-01\nTotal: 12.50\nCurrency: USD",
+        invoice_file="/dev/null",
+        input_module=None,
+    )
+    assert extracted["currency"] == "USD", (
+        f"template's static currency={tpl.options['currency']!r} clobbered "
+        f"the extracted value; got {extracted['currency']!r}"
+    )
+
+
+def test_missing_currency_falls_back_to_option() -> None:
+    """No `currency` field extracted -> the option's default is emitted."""
+    tpl = _currency_template({}, "currency_default.yml")
+    extracted = tpl.extract(
+        "Any Vendor Ltd\nInvoice #42\nDate: 2026-01-01\nTotal: 12.50",
+        invoice_file="/dev/null",
+        input_module=None,
+    )
+    assert extracted["currency"] == "EUR"
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- `invoice_template.py:265` unconditionally overwrites any currency the template extracted with `self.options["currency"]` (default `"EUR"`), silently defeating dynamic currency extraction.
- Change to `output.setdefault("currency", self.options["currency"])`: extracted value wins, option is fallback only.

Surfaced in the outside 1.0 review. Fully backwards-compatible with the 200+ bundled templates -- none of them extract currency dynamically today; they all set `options.currency` explicitly, which still applies via the same fallback.

## Before

```python
tpl.fields = {"currency": {"parser": "regex", "regex": r"Currency:\s+(\w{3})"}}
# document says "Currency: USD", template option currency: EUR
tpl.extract(text)["currency"] == "EUR"  # clobbered
```

## After

```python
tpl.extract(text)["currency"] == "USD"  # preserved
```

## Test plan

- [x] `pytest tests/test_invoice_template.py` — 8/8 passing including the two new regression tests
- [x] Verified with `git stash` that the pre-existing `test_content_json` failure (`de.qualityhosting.yml` date regex miss) is unrelated to this change