### PR TITLE
chore(pyproject): relax hard `==` pins in optional extras

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -225,8 +225,6 @@ def tests(session: nox.Session) -> None:
         "--extra",
         "pdfplumber",
         "--extra",
-        "pyyaml",
-        "--extra",
         "ai",
         "--extra",
         "dateparser",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,21 +85,22 @@ xdoctest = ["xdoctest[colors] >= 1.2"]
 ai = ["httpx >= 0.27"]
 camelot = ["camelot-py >= 1.0"]
 dateparser = ["dateparser >= 1.2.0"]
-defusedxml = ["defusedxml == 0.7.1"]
+defusedxml = ["defusedxml >= 0.7.1"]
 doctr = ["python-doctr[torch] >= 0.8"]
 paddleocr = ["paddleocr >= 2.7", "paddlepaddle >= 2.5", "pypdfium2 >= 4"]
 googlevision = [
-    "google-cloud-storage == 2.18.2",
-    "google-cloud-vision == 3.8.1",
+    "google-cloud-storage >= 2.18",
+    "google-cloud-vision >= 3.8",
 ]
 hotpdf = ["hotpdf >= 0.1.0"]
-ocr = ["ghostscript == 0.7"]
+ocr = ["ghostscript >= 0.7"]
 ocrmypdf = ["ocrmypdf >= 14.4.0"]
 pdfium = ["pypdfium2 >= 4"]
+# pdfminer-six deliberately pinned: pdfplumber 0.11.x is only tested against
+# this build; camelot needs a newer build (see [tool.uv].conflicts below).
 pdfminer-six = ["pdfminer-six == 20231228"]
 pdfoxide = ["pdf-oxide >= 0.3"]
-pdfplumber = ["pdfplumber == 0.11.4"]
-pyyaml = ["pyyaml == 6.0.2"]
+pdfplumber = ["pdfplumber >= 0.11.4, < 0.12"]
 
 [tool.uv]
 package = true

--- a/uv.lock
+++ b/uv.lock
@@ -1333,9 +1333,6 @@ pdfoxide = [
 pdfplumber = [
     { name = "pdfplumber" },
 ]
-pyyaml = [
-    { name = "pyyaml" },
-]
 
 [package.dev-dependencies]
 dev = [
@@ -1382,10 +1379,10 @@ requires-dist = [
     { name = "camelot-py", marker = "extra == 'camelot'", specifier = ">=1.0" },
     { name = "click", specifier = ">=8.0.1" },
     { name = "dateparser", marker = "extra == 'dateparser'", specifier = ">=1.2.0" },
-    { name = "defusedxml", marker = "extra == 'defusedxml'", specifier = "==0.7.1" },
-    { name = "ghostscript", marker = "extra == 'ocr'", specifier = "==0.7" },
-    { name = "google-cloud-storage", marker = "extra == 'googlevision'", specifier = "==2.18.2" },
-    { name = "google-cloud-vision", marker = "extra == 'googlevision'", specifier = "==3.8.1" },
+    { name = "defusedxml", marker = "extra == 'defusedxml'", specifier = ">=0.7.1" },
+    { name = "ghostscript", marker = "extra == 'ocr'", specifier = ">=0.7" },
+    { name = "google-cloud-storage", marker = "extra == 'googlevision'", specifier = ">=2.18" },
+    { name = "google-cloud-vision", marker = "extra == 'googlevision'", specifier = ">=3.8" },
     { name = "hotpdf", marker = "extra == 'hotpdf'", specifier = ">=0.1.0" },
     { name = "httpx", marker = "extra == 'ai'", specifier = ">=0.27" },
     { name = "ocrmypdf", marker = "extra == 'ocrmypdf'", specifier = ">=14.4.0" },
@@ -1393,17 +1390,16 @@ requires-dist = [
     { name = "paddlepaddle", marker = "extra == 'paddleocr'", specifier = ">=2.5" },
     { name = "pdf-oxide", marker = "extra == 'pdfoxide'", specifier = ">=0.3" },
     { name = "pdfminer-six", marker = "extra == 'pdfminer-six'", specifier = "==20231228" },
-    { name = "pdfplumber", marker = "extra == 'pdfplumber'", specifier = "==0.11.4" },
+    { name = "pdfplumber", marker = "extra == 'pdfplumber'", specifier = ">=0.11.4,<0.12" },
     { name = "pypdfium2", marker = "extra == 'paddleocr'", specifier = ">=4" },
     { name = "pypdfium2", marker = "extra == 'pdfium'", specifier = ">=4" },
     { name = "python-dateutil", specifier = ">=2.8" },
     { name = "python-doctr", extras = ["torch"], marker = "extra == 'doctr'", specifier = ">=0.8" },
     { name = "pyyaml", specifier = ">=6.0" },
-    { name = "pyyaml", marker = "extra == 'pyyaml'", specifier = "==6.0.2" },
     { name = "regex", marker = "python_full_version < '3.12'", specifier = ">=2024.4.16" },
     { name = "regex", marker = "python_full_version >= '3.12'", specifier = ">=2025.2.10" },
 ]
-provides-extras = ["ai", "camelot", "dateparser", "defusedxml", "doctr", "paddleocr", "googlevision", "hotpdf", "ocr", "ocrmypdf", "pdfium", "pdfminer-six", "pdfoxide", "pdfplumber", "pyyaml"]
+provides-extras = ["ai", "camelot", "dateparser", "defusedxml", "doctr", "paddleocr", "googlevision", "hotpdf", "ocr", "ocrmypdf", "pdfium", "pdfminer-six", "pdfoxide", "pdfplumber"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

outside 1.0 review flagged the `==` pins in extras as latent resolver-conflict traps for downstream users (conda-forge feedstocks, Odoo deployments layering on top). Relax pins where they were frozen-debt rather than a real requirement.

| Extra | Before | After | Rationale |
|-------|--------|-------|-----------|
| `defusedxml` | `== 0.7.1` | `>= 0.7.1` | mature; no breaking-change history |
| `ocr` (ghostscript) | `== 0.7` | `>= 0.7` | tiny surface, stable |
| `googlevision` | `== 2.18.2` / `== 3.8.1` | `>= 2.18` / `>= 3.8` | google-cloud-* pkgs follow semver |
| `pdfplumber` | `== 0.11.4` | `>= 0.11.4, < 0.12` | real API surface; keep the major cap |
| `pdfminer-six` | `== 20231228` | `== 20231228` (unchanged, +comment) | pdfplumber 0.11.x vs camelot conflict already covered by `[tool.uv].conflicts` |
| `pyyaml` | `== 6.0.2` | **removed** | `pyyaml >= 6.0` is a core dependency; the extra was a no-op |

No references to `invoice2data[pyyaml]` anywhere in the repo or docs. `uv lock` re-run; runtime deps unchanged for the default install.

## Test plan

- [x] `uv lock` resolves cleanly (211 packages)
- [ ] CI: full matrix