### PR TITLE
refactor: split library API out of `__main__`, replace user-facing asserts

### DIFF
--- a/src/invoice2data/__init__.py
+++ b/src/invoice2data/__init__.py
@@ -1,10 +1,11 @@
 """Invoice2Data."""
 
-from .__main__ import Invoice2Data
-from .__main__ import extract_data
+from .api import Invoice2Data
+from .api import extract_data
 from .exceptions import InvoiceProcessingError
 from .exceptions import NoTemplateFoundError
 from .exceptions import RequiredFieldsMissingError
+from .exceptions import TemplateSyntaxError
 
 
 __all__ = [
@@ -12,5 +13,6 @@ __all__ = [
     "InvoiceProcessingError",
     "NoTemplateFoundError",
     "RequiredFieldsMissingError",
+    "TemplateSyntaxError",
     "extract_data",
 ]

--- a/src/invoice2data/__main__.py
+++ b/src/invoice2data/__main__.py
@@ -1,5 +1,12 @@
 #!/usr/bin/python
-"""Command-line interface."""
+"""Command-line interface.
+
+The library API (``extract_data``, ``Invoice2Data``, backend cascade helpers)
+lives in :mod:`invoice2data.api`; this module is now a thin click shell that
+imports from there and adds the CLI's ANSI/log-formatter plumbing, argument
+parsing, interactive template builder, and file-move helpers. Importing the
+library no longer forces ``click`` into the caller's environment.
+"""
 
 import datetime
 import json
@@ -14,9 +21,10 @@ from typing import ClassVar
 
 import click
 
-from invoice2data.exceptions import NoTemplateFoundError
-from invoice2data.exceptions import RequiredFieldsMissingError
-from invoice2data.extract.invoice_template import InvoiceTemplate
+from invoice2data.api import DEFAULT_INPUT_READERS
+from invoice2data.api import Invoice2Data
+from invoice2data.api import extract_data
+from invoice2data.api import input_mapping
 from invoice2data.extract.loader import read_templates
 from invoice2data.extract.template_builder import field_regex
 from invoice2data.extract.template_builder import preview_field
@@ -24,13 +32,17 @@ from invoice2data.extract.template_builder import set_field_regex
 from invoice2data.extract.template_builder import suggested_template
 from invoice2data.extract.template_builder import to_yaml
 
-from .input import INPUT_MODULES
-from .input import extract_text
-from .input import is_available
-from .input import ocrmypdf
-from .input import pdfium
-from .input import pdftotext
-from .input import text
+# Private helpers re-exported for backwards compatibility with pre-refactor
+# callers (tests + downstream code doing `from invoice2data.__main__ import _foo`).
+# New code should import these from :mod:`invoice2data.api`.
+# `X as X` = explicit re-export (mypy strict --no-implicit-reexport).
+from .api import _by_priority as _by_priority
+from .api import _match_template as _match_template
+from .api import _preferred_module as _preferred_module
+from .api import _resolve_readers as _resolve_readers
+from .api import _run_template as _run_template
+from .api import _safe_to_text as _safe_to_text
+from .api import _sample_text as _sample_text
 from .output import to_csv
 from .output import to_json
 from .output import to_xml
@@ -38,18 +50,17 @@ from .output import to_xml
 
 logger = logging.getLogger()
 
-# Backend registry lives in invoice2data.input (see input.__interface__).
-input_mapping = INPUT_MODULES
-
-#: Default ordered text backends tried when ``input_module`` is not forced.
-#: ``pdfium`` (pypdfium2) leads — fast and dependency-light — with ``pdftotext``
-#: (poppler ``-layout``, the layout/accuracy anchor) as the fallback. The
-#: benchmark (docs/backend-benchmark.md) shows this matches pdftotext's accuracy
-#: while running faster: the cascade falls back automatically when pdfium fails
-#: to match, misses a required field, or drops a declared line-item table, and
-#: layout/area-sensitive templates pin ``input_module: pdftotext`` for the rest.
-#: Backends whose dependency is missing are skipped automatically.
-DEFAULT_INPUT_READERS = [pdfium, pdftotext]
+# The names above (``DEFAULT_INPUT_READERS``, ``Invoice2Data``, ``extract_data``,
+# ``input_mapping``) are re-exported so any pre-refactor import that reached
+# into ``invoice2data.__main__`` keeps working. New code should import from
+# :mod:`invoice2data.api`.
+__all__ = [
+    "DEFAULT_INPUT_READERS",
+    "Invoice2Data",
+    "extract_data",
+    "input_mapping",
+    "main",
+]
 
 output_mapping = {
     "csv": to_csv,
@@ -144,431 +155,6 @@ logger.propagate = False
 
 if not logger.handlers:
     logger.addHandler(stream_handler)
-
-
-def extract_data(  # noqa: C901
-    invoicefile: str,
-    templates: list[InvoiceTemplate] | None = None,
-    input_module: Any = None,
-    ai_fallback: bool = False,
-    raise_on_error: bool = False,
-) -> dict[str, Any]:
-    """Extracts structured data from PDF/image invoices.
-
-    This function uses the text extracted from a PDF file or image and
-    pre-defined regex templates to find structured data.
-
-    Reads template if no template assigned.
-    Required fields are matches from templates.
-
-    Args:
-        invoicefile (str): Path of electronic invoice file in PDF, JPEG, PNG
-        templates (list[InvoiceTemplate] | None): List of instances of class `InvoiceTemplate`.
-                                            Templates are loaded using `read_template` function in `loader.py`.
-        input_module (Any, optional): Backend used to extract text from the
-            given `invoicefile`, as a module or a registry name (e.g.
-            'pdftotext', 'pdfium', 'pdfminer', 'tesseract', 'text'). When
-            ``None`` (the default), a cascade of backends
-            (``DEFAULT_INPUT_READERS``) is tried in order until one yields a
-            template match with all required fields.
-        ai_fallback (bool, optional): When True and no template matches (or every
-            match is incomplete) and OCR does not help, extract fields with the
-            configured AI provider (see ``INVOICE2DATA_AI_*`` env vars). Result is
-            tagged ``extraction_method: "ai"``. Opt-in; defaults to False.
-        raise_on_error (bool, optional): When True, raise a typed
-            :class:`~invoice2data.exceptions.InvoiceProcessingError` on failure
-            instead of returning ``{}`` -- ``RequiredFieldsMissingError`` when a
-            template matched but a required field could not be parsed, otherwise
-            ``NoTemplateFoundError``. Defaults to False (the historical ``{}`` contract).
-
-    Returns:
-        dict[str, Any]: Extracted and matched fields, or an empty dict ``{}`` if
-            text extraction fails or no template matches (unless
-            ``raise_on_error`` is set).
-
-    Raises:
-        InvoiceProcessingError: When ``raise_on_error`` is True and extraction
-            fails (``RequiredFieldsMissingError`` or ``NoTemplateFoundError``).
-
-    Notes:
-        Import the required `input_module` when using invoice2data as a library.
-        A template may pin the backend it was authored for with a top-level
-        ``input_module:`` key; that backend is then used for that template
-        regardless of which one matched it first.
-
-    See Also:
-        read_template: Function to load templates.
-        InvoiceTemplate: Class representing a single invoice template.
-
-    Examples:
-        When using `invoice2data` as a library:
-
-        >>> from invoice2data.input import pdftotext
-        >>> extract_data("./tests/compare/oyo.pdf", None, pdftotext)
-        {'issuer': 'OYO', 'template_name': 'com.oyo.invoice.yml', 'amount': 1939.0, 'date': datetime.datetime(2017, 12, 31, 0, 0), 'invoice_number': 'IBZY2087', 'currency': 'INR', 'hotel_details': ' OYO 4189 Resort Nanganallur', 'date_check_in': datetime.datetime(2017, 12, 31, 0, 0), 'date_check_out': datetime.datetime(2018, 1, 1, 0, 0), 'amount_rooms': 1.0, 'booking_id': 'IBZY2087', 'payment_method': 'Cash at Hotel', 'gstin': '06AABCO6063D1ZQ', 'cin': 'U63090DL2012PTC231770', 'desc': 'Invoice from OYO'}
-
-    """
-    templates = _by_priority(templates or read_templates())
-    readers = _resolve_readers(invoicefile, input_module)
-    # Per-template backend pins apply only in auto (cascade) mode; an explicit
-    # input_module forces that backend, pin or not.
-    auto = input_module is None
-    best: dict[str, Any] | None = None  # complete-but-lineless result, kept as fallback
-    field_errors: list[RequiredFieldsMissingError] = []  # missing-fields reasons (#190)
-
-    for reader in readers:
-        extracted_str = _safe_to_text(reader, invoicefile)
-        if not extracted_str:
-            continue
-        logger.debug(
-            "START %s result ===========================\n%s",
-            reader.__name__,
-            extracted_str,
-        )
-        logger.debug("END %s result =============================", reader.__name__)
-
-        template = _match_template(extracted_str, templates)
-        if template is None:
-            continue
-
-        # A template may pin the backend it was authored for (e.g. an area or
-        # table template that needs poppler's layout). Honour it by re-extracting
-        # with that backend; this also short-circuits straight to the right
-        # backend once a faster default leads the cascade. Pins apply in auto
-        # mode only — an explicit input_module is taken at face value.
-        preferred = _preferred_module(template, used=reader) if auto else None
-        if preferred is not None:
-            preferred_str = _safe_to_text(preferred, invoicefile)
-            preferred_template = (
-                _match_template(preferred_str, templates) if preferred_str else None
-            )
-            if preferred_template is not None:
-                reader = preferred
-                extracted_str = preferred_str
-                template = preferred_template
-
-        logger.info("Using %s template", template["template_name"])
-        result = _run_template(
-            template, extracted_str, invoicefile, reader, field_errors
-        )
-        if result:
-            # A template that declares line items but yields none usually means a
-            # layout-less backend dropped the table: keep the result but try the
-            # next (layout) backend, which may recover the lines.
-            if not auto or not _line_items_missing(template, result):
-                return result
-            best = best or result
-            continue
-        # Matched, but a required field was missing: fall through to the next
-        # backend in the cascade rather than returning an incomplete result.
-
-    # A complete-but-lineless result beats OCR / nothing.
-    if best is not None:
-        return best
-
-    # Nothing matched (or every match was incomplete): try OCR as a last resort.
-    result = _ocr_last_resort(invoicefile, templates, readers)
-    if result:
-        return result
-
-    # Opt-in AI fallback: let an LLM extract fields when no template fit.
-    ai_result = _ai_last_resort(invoicefile, input_module, ai_fallback)
-    if ai_result:
-        return ai_result
-
-    logger.error("No template for %s", invoicefile)
-    if raise_on_error:
-        # A matched-but-incomplete template is a more useful reason than "no
-        # template", so prefer the missing-fields error when we have one.
-        if field_errors:
-            raise field_errors[-1]
-        raise NoTemplateFoundError(f"No template matched {invoicefile}")
-    return {}
-
-
-def _ai_last_resort(
-    invoicefile: str, input_module: Any, ai_fallback: bool
-) -> dict[str, Any]:
-    """Try the configured AI provider when no template matched (opt-in).
-
-    Args:
-        invoicefile (str): Path to the invoice file.
-        input_module (Any): Forced input backend, or None for the cascade.
-        ai_fallback (bool): Whether AI fallback is enabled.
-
-    Returns:
-        dict[str, Any]: AI-extracted fields, or ``{}`` when disabled/unavailable.
-    """
-    if not ai_fallback:
-        return {}
-    from .ai.fallback import ai_fallback_extract
-
-    return ai_fallback_extract(_sample_text(invoicefile, input_module))
-
-
-def _resolve_readers(invoicefile: str, input_module: Any) -> list[Any]:
-    """Return the ordered list of input backends to try for ``invoicefile``.
-
-    Args:
-        invoicefile (str): Path to the invoice file.
-        input_module (Any): An explicit backend (module or registry name) to
-            force a single-backend pass, or ``None`` to use the default cascade.
-
-    Returns:
-        list[Any]: Backends to try, in order.
-    """
-    if isinstance(input_module, str):
-        return [input_mapping[input_module]]
-    if input_module is not None:
-        return [input_module]
-    if invoicefile.lower().endswith(".txt"):
-        return [text]
-    readers = [module for module in DEFAULT_INPUT_READERS if is_available(module)]
-    return readers or [pdftotext]
-
-
-def _safe_to_text(module: Any, invoicefile: str) -> str:
-    """Extract text with ``module``, returning ``""`` on any failure.
-
-    Args:
-        module (Any): An input backend exposing ``to_text``.
-        invoicefile (str): Path to the invoice file.
-
-    Returns:
-        str: The extracted text, or ``""`` if extraction failed or was empty.
-    """
-    try:
-        extracted_str = extract_text(module, invoicefile)
-    except Exception:
-        logger.debug(
-            "Backend %s failed to extract text from %s",
-            module.__name__,
-            invoicefile,
-            exc_info=True,
-        )
-        return ""
-    if not isinstance(extracted_str, str) or not extracted_str.strip():
-        logger.debug("Backend %s produced no text for %s", module.__name__, invoicefile)
-        return ""
-    return extracted_str
-
-
-def _match_template(
-    extracted_str: str, templates: list[InvoiceTemplate]
-) -> InvoiceTemplate | None:
-    """Return the first template whose keywords match the text, else ``None``.
-
-    Args:
-        extracted_str (str): The extracted invoice text.
-        templates (list[InvoiceTemplate]): Candidate templates.
-
-    Returns:
-        InvoiceTemplate | None: The first matching template, or ``None``.
-            ``templates`` is expected to be priority-ordered already (see
-            :func:`_by_priority`, applied once in ``extract_data``).
-    """
-    for template in templates:
-        if template.matches_input(extracted_str):
-            return template
-    return None
-
-
-def _by_priority(templates: list[InvoiceTemplate]) -> list[InvoiceTemplate]:
-    """Order templates by descending ``priority`` (default 5).
-
-    A stable sort, so alphabetical order is preserved within a priority level.
-    Done once per ``extract_data`` call rather than on every template match.
-
-    Args:
-        templates (list[InvoiceTemplate]): Templates to order.
-
-    Returns:
-        list[InvoiceTemplate]: Templates highest-priority first.
-    """
-    return sorted(templates, key=lambda t: t.get("priority", 5), reverse=True)
-
-
-def _line_items_missing(template: InvoiceTemplate, output: dict[str, Any]) -> bool:
-    """Whether a template declares line items but none were extracted.
-
-    A soft-completeness signal for the cascade: a layout-less backend often
-    matches a template and fills the required fields yet produces empty line
-    items (the table collapses without column layout). When that happens the
-    cascade should try the next backend, which may recover the table.
-
-    Args:
-        template (InvoiceTemplate): The matched template.
-        output (dict[str, Any]): The extracted fields.
-
-    Returns:
-        bool: True if the template declares a ``lines``/``tables`` block (or a
-            ``parser: lines`` field) but no non-empty list field was produced.
-    """
-    declares = (
-        "lines" in template
-        or "tables" in template
-        or any(
-            isinstance(field, dict) and field.get("parser") in ("lines", "tables")
-            for field in template.get("fields", {}).values()
-        )
-    )
-    if not declares:
-        return False
-    has_items = any(isinstance(value, list) and value for value in output.values())
-    return not has_items
-
-
-def _preferred_module(template: InvoiceTemplate, used: Any) -> Any:
-    """Resolve a template's declared ``input_module`` when it differs from ``used``.
-
-    Args:
-        template (InvoiceTemplate): The matched template.
-        used (Any): The backend that produced the current text.
-
-    Returns:
-        Any: The preferred backend module to re-extract with, or ``None`` when
-            the template declares none, declares the one already used, or
-            declares one that is unknown or unavailable.
-    """
-    name = template.get("input_module")
-    if not name:
-        return None
-    module = input_mapping.get(name) if isinstance(name, str) else name
-    if module is None:
-        logger.warning(
-            "Template %s declares unknown input_module %r; ignoring",
-            template["template_name"],
-            name,
-        )
-        return None
-    if module is used:
-        return None
-    if not is_available(module):
-        logger.warning(
-            "Template %s prefers input_module %r, but it is unavailable; using %s",
-            template["template_name"],
-            name,
-            used.__name__,
-        )
-        return None
-    return module
-
-
-def _run_template(
-    template: InvoiceTemplate,
-    extracted_str: str,
-    invoicefile: str,
-    reader: Any,
-    errors: list[RequiredFieldsMissingError] | None = None,
-) -> dict[str, Any]:
-    """Run a matched template, returning ``{}`` if required fields are missing.
-
-    Args:
-        template (InvoiceTemplate): The matched template.
-        extracted_str (str): The extracted invoice text.
-        invoicefile (str): Path to the invoice file.
-        reader (Any): The backend that produced ``extracted_str``.
-        errors (list[RequiredFieldsMissingError] | None): When given, a missing-fields
-            failure is appended here (so the caller can surface why it failed).
-
-    Returns:
-        dict[str, Any]: The extracted fields, or ``{}`` when the template matched
-            but a required field could not be parsed.
-    """
-    optimized_str = template.prepare_input(extracted_str)
-    try:
-        return template.extract(optimized_str, invoicefile, reader)
-    except ValueError as exc:
-        logger.debug(
-            "Template %s matched under %s but extraction was incomplete: %s",
-            template["template_name"],
-            reader.__name__,
-            exc,
-        )
-        if errors is not None and isinstance(exc, RequiredFieldsMissingError):
-            errors.append(exc)
-        return {}
-
-
-def _ocr_last_resort(
-    invoicefile: str, templates: list[InvoiceTemplate], readers: list[Any]
-) -> dict[str, Any]:
-    """Try OCR (ocrmypdf) when the primary backends produced no usable match.
-
-    Args:
-        invoicefile (str): Path to the invoice file.
-        templates (list[InvoiceTemplate]): Candidate templates.
-        readers (list[Any]): Backends already attempted (to avoid repeating).
-
-    Returns:
-        dict[str, Any]: Extracted fields from the OCR pass, or ``{}``.
-    """
-    if not ocrmypdf.ocrmypdf_available() or ocrmypdf in readers:
-        return {}
-    logger.debug("Primary backends produced no match; falling back to ocrmypdf")
-    extracted_str = _safe_to_text(ocrmypdf, invoicefile)
-    if not extracted_str:
-        return {}
-    template = _match_template(extracted_str, templates)
-    if template is None:
-        return {}
-    logger.info("Using %s template (ocrmypdf fallback)", template["template_name"])
-    return _run_template(template, extracted_str, invoicefile, ocrmypdf)
-
-
-class Invoice2Data:
-    """Object-oriented interface around :func:`extract_data`.
-
-    Holds a reusable set of templates so several invoices can be processed
-    without reloading templates each time.
-
-    Args:
-        load_built_in_templates (bool): Load the bundled templates on init.
-            Defaults to True.
-    """
-
-    def __init__(self, load_built_in_templates: bool = True) -> None:
-        self.templates: list[InvoiceTemplate] = []
-        if load_built_in_templates:
-            self.templates += read_templates()
-
-    def read_templates(self, path: str) -> None:
-        """Add templates from a user folder to this instance.
-
-        Args:
-            path (str): Folder containing .yml/.json templates to load.
-        """
-        self.templates += read_templates(str(Path(path).resolve()))
-
-    def extract_data(self, path: str, input_module: Any = None) -> dict[str, Any]:
-        """Extract data from an invoice using this instance's templates.
-
-        Args:
-            path (str): Path to the invoice file.
-            input_module (Any): Text-extraction module to use. Defaults to None
-                (auto-detect between text and pdftotext).
-
-        Returns:
-            dict[str, Any]: Extracted fields, or an empty dict if none matched.
-        """
-        return extract_data(path, self.templates, input_module)
-
-
-def _sample_text(invoicefile: str, input_module: Any = None) -> str:
-    """Return the first non-empty text extracted from a sample file.
-
-    Args:
-        invoicefile (str): Path to the sample document.
-        input_module (Any): Forced input backend, or None for the cascade.
-
-    Returns:
-        str: The extracted text, or ``""`` if every backend failed.
-    """
-    for reader in _resolve_readers(invoicefile, input_module):
-        text = _safe_to_text(reader, invoicefile)
-        if text:
-            return text
-    return ""
 
 
 def _default_template_path(template: dict[str, Any]) -> str:

--- a/src/invoice2data/api.py
+++ b/src/invoice2data/api.py
@@ -1,0 +1,478 @@
+"""Library API for invoice2data.
+
+Structural refactor for the 1.x line: the API used to live inside
+:mod:`invoice2data.__main__`, which forced ``import invoice2data`` to pull in
+``click`` and the CLI's ANSI/log-formatter plumbing. This module owns
+:func:`extract_data` and the :class:`Invoice2Data` class; :mod:`__main__` is
+now a thin click shell that imports from here. Public symbols keep their
+existing import paths (``from invoice2data import extract_data``) via
+``__init__.py`` re-exports.
+"""
+
+import logging
+from pathlib import Path
+from typing import Any
+
+from .exceptions import NoTemplateFoundError
+from .exceptions import RequiredFieldsMissingError
+from .extract.invoice_template import InvoiceTemplate
+from .extract.loader import read_templates
+from .input import INPUT_MODULES
+from .input import extract_text
+from .input import is_available
+from .input import ocrmypdf
+from .input import pdfium
+from .input import pdftotext
+from .input import text
+
+
+logger = logging.getLogger(__name__)
+
+#: Alias kept for backwards compatibility with call sites that referenced it
+#: via ``invoice2data.__main__.input_mapping``. New code should import
+#: :data:`invoice2data.input.INPUT_MODULES` directly.
+input_mapping = INPUT_MODULES
+
+#: Default ordered text backends tried when ``input_module`` is not forced.
+#: ``pdfium`` (pypdfium2) leads -- fast and dependency-light -- with
+#: ``pdftotext`` (poppler ``-layout``, the layout/accuracy anchor) as the
+#: fallback. The benchmark (docs/backend-benchmark.md) shows this matches
+#: pdftotext's accuracy while running faster: the cascade falls back
+#: automatically when pdfium fails to match, misses a required field, or drops
+#: a declared line-item table, and layout/area-sensitive templates pin
+#: ``input_module: pdftotext`` for the rest. Backends whose dependency is
+#: missing are skipped automatically.
+DEFAULT_INPUT_READERS = [pdfium, pdftotext]
+
+
+__all__ = [
+    "DEFAULT_INPUT_READERS",
+    "Invoice2Data",
+    "extract_data",
+    "input_mapping",
+]
+
+
+def extract_data(  # noqa: C901
+    invoicefile: str,
+    templates: list[InvoiceTemplate] | None = None,
+    input_module: Any = None,
+    ai_fallback: bool = False,
+    raise_on_error: bool = False,
+) -> dict[str, Any]:
+    """Extracts structured data from PDF/image invoices.
+
+    This function uses the text extracted from a PDF file or image and
+    pre-defined regex templates to find structured data.
+
+    Reads template if no template assigned.
+    Required fields are matches from templates.
+
+    Args:
+        invoicefile (str): Path of electronic invoice file in PDF, JPEG, PNG
+        templates (list[InvoiceTemplate] | None): List of instances of class `InvoiceTemplate`.
+                                            Templates are loaded using `read_template` function in `loader.py`.
+        input_module (Any, optional): Backend used to extract text from the
+            given `invoicefile`, as a module or a registry name (e.g.
+            'pdftotext', 'pdfium', 'pdfminer', 'tesseract', 'text'). When
+            ``None`` (the default), a cascade of backends
+            (``DEFAULT_INPUT_READERS``) is tried in order until one yields a
+            template match with all required fields.
+        ai_fallback (bool, optional): When True and no template matches (or every
+            match is incomplete) and OCR does not help, extract fields with the
+            configured AI provider (see ``INVOICE2DATA_AI_*`` env vars). Result is
+            tagged ``extraction_method: "ai"``. Opt-in; defaults to False.
+        raise_on_error (bool, optional): When True, raise a typed
+            :class:`~invoice2data.exceptions.InvoiceProcessingError` on failure
+            instead of returning ``{}`` -- ``RequiredFieldsMissingError`` when a
+            template matched but a required field could not be parsed, otherwise
+            ``NoTemplateFoundError``. Defaults to False (the historical ``{}`` contract).
+
+    Returns:
+        dict[str, Any]: Extracted and matched fields, or an empty dict ``{}`` if
+            text extraction fails or no template matches (unless
+            ``raise_on_error`` is set).
+
+    Raises:
+        InvoiceProcessingError: When ``raise_on_error`` is True and extraction
+            fails (``RequiredFieldsMissingError`` or ``NoTemplateFoundError``).
+
+    Notes:
+        Import the required `input_module` when using invoice2data as a library.
+        A template may pin the backend it was authored for with a top-level
+        ``input_module:`` key; that backend is then used for that template
+        regardless of which one matched it first.
+
+    See Also:
+        read_template: Function to load templates.
+        InvoiceTemplate: Class representing a single invoice template.
+
+    Examples:
+        When using `invoice2data` as a library:
+
+        >>> from invoice2data.input import pdftotext
+        >>> extract_data("./tests/compare/oyo.pdf", None, pdftotext)
+        {'issuer': 'OYO', 'template_name': 'com.oyo.invoice.yml', 'amount': 1939.0, 'date': datetime.datetime(2017, 12, 31, 0, 0), 'invoice_number': 'IBZY2087', 'currency': 'INR', 'hotel_details': ' OYO 4189 Resort Nanganallur', 'date_check_in': datetime.datetime(2017, 12, 31, 0, 0), 'date_check_out': datetime.datetime(2018, 1, 1, 0, 0), 'amount_rooms': 1.0, 'booking_id': 'IBZY2087', 'payment_method': 'Cash at Hotel', 'gstin': '06AABCO6063D1ZQ', 'cin': 'U63090DL2012PTC231770', 'desc': 'Invoice from OYO'}
+
+    """
+    templates = _by_priority(templates or read_templates())
+    readers = _resolve_readers(invoicefile, input_module)
+    # Per-template backend pins apply only in auto (cascade) mode; an explicit
+    # input_module forces that backend, pin or not.
+    auto = input_module is None
+    best: dict[str, Any] | None = None  # complete-but-lineless result, kept as fallback
+    field_errors: list[RequiredFieldsMissingError] = []  # missing-fields reasons (#190)
+
+    for reader in readers:
+        extracted_str = _safe_to_text(reader, invoicefile)
+        if not extracted_str:
+            continue
+        logger.debug(
+            "START %s result ===========================\n%s",
+            reader.__name__,
+            extracted_str,
+        )
+        logger.debug("END %s result =============================", reader.__name__)
+
+        template = _match_template(extracted_str, templates)
+        if template is None:
+            continue
+
+        # A template may pin the backend it was authored for (e.g. an area or
+        # table template that needs poppler's layout). Honour it by re-extracting
+        # with that backend; this also short-circuits straight to the right
+        # backend once a faster default leads the cascade. Pins apply in auto
+        # mode only -- an explicit input_module is taken at face value.
+        preferred = _preferred_module(template, used=reader) if auto else None
+        if preferred is not None:
+            preferred_str = _safe_to_text(preferred, invoicefile)
+            preferred_template = (
+                _match_template(preferred_str, templates) if preferred_str else None
+            )
+            if preferred_template is not None:
+                reader = preferred
+                extracted_str = preferred_str
+                template = preferred_template
+
+        logger.info("Using %s template", template["template_name"])
+        result = _run_template(
+            template, extracted_str, invoicefile, reader, field_errors
+        )
+        if result:
+            # A template that declares line items but yields none usually means a
+            # layout-less backend dropped the table: keep the result but try the
+            # next (layout) backend, which may recover the lines.
+            if not auto or not _line_items_missing(template, result):
+                return result
+            best = best or result
+            continue
+        # Matched, but a required field was missing: fall through to the next
+        # backend in the cascade rather than returning an incomplete result.
+
+    # A complete-but-lineless result beats OCR / nothing.
+    if best is not None:
+        return best
+
+    # Nothing matched (or every match was incomplete): try OCR as a last resort.
+    result = _ocr_last_resort(invoicefile, templates, readers)
+    if result:
+        return result
+
+    # Opt-in AI fallback: let an LLM extract fields when no template fit.
+    ai_result = _ai_last_resort(invoicefile, input_module, ai_fallback)
+    if ai_result:
+        return ai_result
+
+    logger.error("No template for %s", invoicefile)
+    if raise_on_error:
+        # A matched-but-incomplete template is a more useful reason than "no
+        # template", so prefer the missing-fields error when we have one.
+        if field_errors:
+            raise field_errors[-1]
+        raise NoTemplateFoundError(f"No template matched {invoicefile}")
+    return {}
+
+
+def _ai_last_resort(
+    invoicefile: str, input_module: Any, ai_fallback: bool
+) -> dict[str, Any]:
+    """Try the configured AI provider when no template matched (opt-in).
+
+    Args:
+        invoicefile (str): Path to the invoice file.
+        input_module (Any): Forced input backend, or None for the cascade.
+        ai_fallback (bool): Whether AI fallback is enabled.
+
+    Returns:
+        dict[str, Any]: AI-extracted fields, or ``{}`` when disabled/unavailable.
+    """
+    if not ai_fallback:
+        return {}
+    from .ai.fallback import ai_fallback_extract
+
+    return ai_fallback_extract(_sample_text(invoicefile, input_module))
+
+
+def _resolve_readers(invoicefile: str, input_module: Any) -> list[Any]:
+    """Return the ordered list of input backends to try for ``invoicefile``.
+
+    Args:
+        invoicefile (str): Path to the invoice file.
+        input_module (Any): An explicit backend (module or registry name) to
+            force a single-backend pass, or ``None`` to use the default cascade.
+
+    Returns:
+        list[Any]: Backends to try, in order.
+    """
+    if isinstance(input_module, str):
+        return [input_mapping[input_module]]
+    if input_module is not None:
+        return [input_module]
+    if invoicefile.lower().endswith(".txt"):
+        return [text]
+    readers = [module for module in DEFAULT_INPUT_READERS if is_available(module)]
+    return readers or [pdftotext]
+
+
+def _safe_to_text(module: Any, invoicefile: str) -> str:
+    """Extract text with ``module``, returning ``""`` on any failure.
+
+    Args:
+        module (Any): An input backend exposing ``to_text``.
+        invoicefile (str): Path to the invoice file.
+
+    Returns:
+        str: The extracted text, or ``""`` if extraction failed or was empty.
+    """
+    try:
+        extracted_str = extract_text(module, invoicefile)
+    except Exception:
+        logger.debug(
+            "Backend %s failed to extract text from %s",
+            module.__name__,
+            invoicefile,
+            exc_info=True,
+        )
+        return ""
+    if not isinstance(extracted_str, str) or not extracted_str.strip():
+        logger.debug("Backend %s produced no text for %s", module.__name__, invoicefile)
+        return ""
+    return extracted_str
+
+
+def _match_template(
+    extracted_str: str, templates: list[InvoiceTemplate]
+) -> InvoiceTemplate | None:
+    """Return the first template whose keywords match the text, else ``None``.
+
+    Args:
+        extracted_str (str): The extracted invoice text.
+        templates (list[InvoiceTemplate]): Candidate templates.
+
+    Returns:
+        InvoiceTemplate | None: The first matching template, or ``None``.
+            ``templates`` is expected to be priority-ordered already (see
+            :func:`_by_priority`, applied once in ``extract_data``).
+    """
+    for template in templates:
+        if template.matches_input(extracted_str):
+            return template
+    return None
+
+
+def _by_priority(templates: list[InvoiceTemplate]) -> list[InvoiceTemplate]:
+    """Order templates by descending ``priority`` (default 5).
+
+    A stable sort, so alphabetical order is preserved within a priority level.
+    Done once per ``extract_data`` call rather than on every template match.
+
+    Args:
+        templates (list[InvoiceTemplate]): Templates to order.
+
+    Returns:
+        list[InvoiceTemplate]: Templates highest-priority first.
+    """
+    return sorted(templates, key=lambda t: t.get("priority", 5), reverse=True)
+
+
+def _line_items_missing(template: InvoiceTemplate, output: dict[str, Any]) -> bool:
+    """Whether a template declares line items but none were extracted.
+
+    A soft-completeness signal for the cascade: a layout-less backend often
+    matches a template and fills the required fields yet produces empty line
+    items (the table collapses without column layout). When that happens the
+    cascade should try the next backend, which may recover the table.
+
+    Args:
+        template (InvoiceTemplate): The matched template.
+        output (dict[str, Any]): The extracted fields.
+
+    Returns:
+        bool: True if the template declares a ``lines``/``tables`` block (or a
+            ``parser: lines`` field) but no non-empty list field was produced.
+    """
+    declares = (
+        "lines" in template
+        or "tables" in template
+        or any(
+            isinstance(field, dict) and field.get("parser") in ("lines", "tables")
+            for field in template.get("fields", {}).values()
+        )
+    )
+    if not declares:
+        return False
+    has_items = any(isinstance(value, list) and value for value in output.values())
+    return not has_items
+
+
+def _preferred_module(template: InvoiceTemplate, used: Any) -> Any:
+    """Resolve a template's declared ``input_module`` when it differs from ``used``.
+
+    Args:
+        template (InvoiceTemplate): The matched template.
+        used (Any): The backend that produced the current text.
+
+    Returns:
+        Any: The preferred backend module to re-extract with, or ``None`` when
+            the template declares none, declares the one already used, or
+            declares one that is unknown or unavailable.
+    """
+    name = template.get("input_module")
+    if not name:
+        return None
+    module = input_mapping.get(name) if isinstance(name, str) else name
+    if module is None:
+        logger.warning(
+            "Template %s declares unknown input_module %r; ignoring",
+            template["template_name"],
+            name,
+        )
+        return None
+    if module is used:
+        return None
+    if not is_available(module):
+        logger.warning(
+            "Template %s prefers input_module %r, but it is unavailable; using %s",
+            template["template_name"],
+            name,
+            used.__name__,
+        )
+        return None
+    return module
+
+
+def _run_template(
+    template: InvoiceTemplate,
+    extracted_str: str,
+    invoicefile: str,
+    reader: Any,
+    errors: list[RequiredFieldsMissingError] | None = None,
+) -> dict[str, Any]:
+    """Run a matched template, returning ``{}`` if required fields are missing.
+
+    Args:
+        template (InvoiceTemplate): The matched template.
+        extracted_str (str): The extracted invoice text.
+        invoicefile (str): Path to the invoice file.
+        reader (Any): The backend that produced ``extracted_str``.
+        errors (list[RequiredFieldsMissingError] | None): When given, a missing-fields
+            failure is appended here (so the caller can surface why it failed).
+
+    Returns:
+        dict[str, Any]: The extracted fields, or ``{}`` when the template matched
+            but a required field could not be parsed.
+    """
+    optimized_str = template.prepare_input(extracted_str)
+    try:
+        return template.extract(optimized_str, invoicefile, reader)
+    except ValueError as exc:
+        logger.debug(
+            "Template %s matched under %s but extraction was incomplete: %s",
+            template["template_name"],
+            reader.__name__,
+            exc,
+        )
+        if errors is not None and isinstance(exc, RequiredFieldsMissingError):
+            errors.append(exc)
+        return {}
+
+
+def _ocr_last_resort(
+    invoicefile: str, templates: list[InvoiceTemplate], readers: list[Any]
+) -> dict[str, Any]:
+    """Try OCR (ocrmypdf) when the primary backends produced no usable match.
+
+    Args:
+        invoicefile (str): Path to the invoice file.
+        templates (list[InvoiceTemplate]): Candidate templates.
+        readers (list[Any]): Backends already attempted (to avoid repeating).
+
+    Returns:
+        dict[str, Any]: Extracted fields from the OCR pass, or ``{}``.
+    """
+    if not ocrmypdf.ocrmypdf_available() or ocrmypdf in readers:
+        return {}
+    logger.debug("Primary backends produced no match; falling back to ocrmypdf")
+    extracted_str = _safe_to_text(ocrmypdf, invoicefile)
+    if not extracted_str:
+        return {}
+    template = _match_template(extracted_str, templates)
+    if template is None:
+        return {}
+    logger.info("Using %s template (ocrmypdf fallback)", template["template_name"])
+    return _run_template(template, extracted_str, invoicefile, ocrmypdf)
+
+
+def _sample_text(invoicefile: str, input_module: Any = None) -> str:
+    """Return the first non-empty text extracted from a sample file.
+
+    Args:
+        invoicefile (str): Path to the sample document.
+        input_module (Any): Forced input backend, or None for the cascade.
+
+    Returns:
+        str: The extracted text, or ``""`` if every backend failed.
+    """
+    for reader in _resolve_readers(invoicefile, input_module):
+        sampled = _safe_to_text(reader, invoicefile)
+        if sampled:
+            return sampled
+    return ""
+
+
+class Invoice2Data:
+    """Object-oriented interface around :func:`extract_data`.
+
+    Holds a reusable set of templates so several invoices can be processed
+    without reloading templates each time.
+
+    Args:
+        load_built_in_templates (bool): Load the bundled templates on init.
+            Defaults to True.
+    """
+
+    def __init__(self, load_built_in_templates: bool = True) -> None:
+        self.templates: list[InvoiceTemplate] = []
+        if load_built_in_templates:
+            self.templates += read_templates()
+
+    def read_templates(self, path: str) -> None:
+        """Add templates from a user folder to this instance.
+
+        Args:
+            path (str): Folder containing .yml/.json templates to load.
+        """
+        self.templates += read_templates(str(Path(path).resolve()))
+
+    def extract_data(self, path: str, input_module: Any = None) -> dict[str, Any]:
+        """Extract data from an invoice using this instance's templates.
+
+        Args:
+            path (str): Path to the invoice file.
+            input_module (Any): Text-extraction module to use. Defaults to None
+                (auto-detect between text and pdftotext).
+
+        Returns:
+            dict[str, Any]: Extracted fields, or an empty dict if none matched.
+        """
+        return extract_data(path, self.templates, input_module)

--- a/src/invoice2data/exceptions.py
+++ b/src/invoice2data/exceptions.py
@@ -46,12 +46,14 @@ class RequiredFieldsMissingError(InvoiceProcessingError, ValueError):
 class TemplateSyntaxError(InvoiceProcessingError, ValueError):
     """A template's configuration is malformed (author-side error).
 
-    Raised when a template's ``area`` block is missing required keys.
-    Replaces the ``AssertionError`` raised by pre-1.x versions -- asserts
-    silently vanish under ``python -O`` and expose an internal invariant
-    class to library callers. Subclasses :class:`ValueError` so the
-    input-backend cascade's existing ``except ValueError`` retry handling
-    continues to skip a broken template gracefully.
+    Raised when a template's ``replace`` block, ``lines`` settings, ``tables``
+    keys, a numeric field's decimal-separator setting, or an input backend's
+    ``area`` block are missing or ill-formed. Replaces the ``AssertionError``
+    raised by pre-1.x versions -- asserts silently vanish under ``python -O``
+    and expose an internal invariant class to library callers. Subclasses
+    :class:`ValueError` so the input-backend cascade's existing
+    ``except ValueError`` retry handling continues to skip a broken template
+    gracefully.
 
     Args:
         message (str): Human-readable description of what is wrong.

--- a/src/invoice2data/extract/invoice_template.py
+++ b/src/invoice2data/extract/invoice_template.py
@@ -11,6 +11,7 @@ from pprint import pformat
 from typing import Any
 
 from ..exceptions import RequiredFieldsMissingError
+from ..exceptions import TemplateSyntaxError
 from ..input import extract_text
 from ..input import supports_area
 from . import _dates
@@ -117,10 +118,12 @@ class InvoiceTemplate(OrderedDictType[str, Any]):
 
         # Specific replace
         for replace in self.options.get("replace", []):
-            assert len(replace) == 2, (
-                "Error in Template %s A replace should be a list of exactly 2 elements."
-                % self["template_name"]
-            )
+            if len(replace) != 2:
+                raise TemplateSyntaxError(
+                    "A `replace` entry must be a [pattern, repl] pair "
+                    f"(got {len(replace)} elements)",
+                    self.get("template_name"),
+                )
             optimized_str = _regex.sub(replace[0], replace[1], optimized_str)
 
         return optimized_str
@@ -169,18 +172,31 @@ class InvoiceTemplate(OrderedDictType[str, Any]):
 
         Returns:
             float: The parsed numerical value.
+
+        Raises:
+            TypeError: If ``value`` is not a string (internal invariant).
+            TemplateSyntaxError: If ``options.decimal_separator`` is not a
+                string, or the decimal separator appears more than once in
+                ``value``.
         """
-        assert isinstance(value, str)
+        if not isinstance(value, str):
+            # Internal invariant: parsers upstream always hand us a string;
+            # keep as a runtime TypeError (not asserting on hot path).
+            raise TypeError(f"parse_number expected str, got {type(value).__name__}")
         # Early exit if no thousands separator or custom decimal separator is present
         if not any(char in value for char in r",.'\s"):
             return float(value)
 
-        # Ensure decimal_separator is a string before calling count()
-        assert isinstance(self.options["decimal_separator"], str)
-        assert value.count(self.options["decimal_separator"]) < 2, (
-            f"Error in Template {self['template_name']}: "
-            "Decimal separator cannot be present several times"
-        )
+        if not isinstance(self.options["decimal_separator"], str):
+            raise TemplateSyntaxError(
+                "`options.decimal_separator` must be a string",
+                self.get("template_name"),
+            )
+        if value.count(self.options["decimal_separator"]) >= 2:
+            raise TemplateSyntaxError(
+                "Decimal separator cannot appear more than once in a value",
+                self.get("template_name"),
+            )
 
         # Determine the thousands separator based on the decimal separator
         thousands_separator = "," if self.options["decimal_separator"] == "." else "."
@@ -217,7 +233,8 @@ class InvoiceTemplate(OrderedDictType[str, Any]):
             Any: The coerced value.
 
         Raises:
-            AssertionError: If the target_type is unknown.
+            TemplateSyntaxError: If ``target_type`` is not one of the supported
+                values.
         """
         if target_type == "int":
             if not value:
@@ -229,7 +246,10 @@ class InvoiceTemplate(OrderedDictType[str, Any]):
             return float(self.parse_number(value))
         if target_type == "date" or target_type == "datetime":
             return self.parse_date(value)
-        raise AssertionError("Unknown type")
+        raise TemplateSyntaxError(
+            f"Unknown field type {target_type!r}; expected int/float/date/datetime",
+            self.get("template_name"),
+        )
 
     def extract(
         self, optimized_str: str, invoice_file: str, input_module: Any

--- a/src/invoice2data/extract/parsers/lines.py
+++ b/src/invoice2data/extract/parsers/lines.py
@@ -8,6 +8,7 @@ from re import Match
 from typing import TYPE_CHECKING
 from typing import Any
 
+from ...exceptions import TemplateSyntaxError
 from .. import _regex
 from .regex import _normalize_replacements
 from .regex import _replace_value
@@ -66,11 +67,17 @@ def parse_block(  # noqa: RUF100 C901
     Returns:
         list[dict[str, Any]]: A list of dictionaries, where each dictionary
                                 represents an extracted row with field-value pairs.
+
+    Raises:
+        TemplateSyntaxError: If ``settings`` is missing the required
+            ``line`` regex.
     """
     # Validate settings
-    assert "line" in settings, (
-        "Error in Template %s Line regex missing" % template["template_name"]
-    )
+    if "line" not in settings:
+        raise TemplateSyntaxError(
+            "`lines` parser: missing required `line` regex",
+            template.get("template_name"),
+        )
 
     logger.debug("START lines block content ========================\n%s", content)
     logger.debug("END lines block content ==========================")
@@ -225,18 +232,26 @@ def parse_by_rule(
 
     Returns:
         list[dict[str, Any]]: The parsed lines.
+
+    Raises:
+        TemplateSyntaxError: If ``rule`` is missing the required ``start``
+            or ``end`` regex.
     """
     # First apply default options.
     settings = DEFAULT_OPTIONS.copy()
     settings.update(rule)
 
     # Validate settings
-    assert "start" in settings, (
-        "Error in Template %s Lines start regex missing" % template["template_name"]
-    )
-    assert "end" in settings, (
-        "Error in Template %s Lines end regex missing" % template["template_name"]
-    )
+    if "start" not in settings:
+        raise TemplateSyntaxError(
+            "`lines` parser: missing required `start` regex",
+            template.get("template_name"),
+        )
+    if "end" not in settings:
+        raise TemplateSyntaxError(
+            "`lines` parser: missing required `end` regex",
+            template.get("template_name"),
+        )
 
     blocks_count = 0
     lines = []

--- a/src/invoice2data/extract/plugins/tables.py
+++ b/src/invoice2data/extract/plugins/tables.py
@@ -4,6 +4,7 @@ from logging import getLogger
 from typing import TYPE_CHECKING
 from typing import Any
 
+from ...exceptions import TemplateSyntaxError
 from .. import _regex
 from ..utils import _apply_grouping
 
@@ -86,9 +87,11 @@ def _extract_and_validate_settings(
     table = plugin_settings
 
     for key in ("start", "end", "body"):
-        assert key in table, (
-            f"Error in Template {self['template_name']} Table {key} regex missing"
-        )
+        if key not in table:
+            raise TemplateSyntaxError(
+                f"`tables` plugin: missing required `{key}` regex",
+                self.get("template_name"),
+            )
     return table
 
 

--- a/tests/test_main_helpers.py
+++ b/tests/test_main_helpers.py
@@ -49,9 +49,12 @@ def test_preferred_module_unknown_is_ignored(
 def test_preferred_module_unavailable_is_ignored(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
-    import invoice2data.__main__ as main_module
+    # `is_available` is looked up on `invoice2data.api` now that the backend
+    # cascade helpers live there (`__main__` re-exports `_preferred_module`
+    # itself but the symbols it closes over resolve inside `api`).
+    import invoice2data.api as api_module
 
-    monkeypatch.setattr(main_module, "is_available", lambda module: False)
+    monkeypatch.setattr(api_module, "is_available", lambda module: False)
     with caplog.at_level(logging.WARNING):
         assert _preferred_module(_template("pdfium"), used=pdftotext) is None
     assert "unavailable" in caplog.text


### PR DESCRIPTION
> **Draft.** Structural refactor -- posting for review of the module split before landing. Behaviour-preserving; test suite green modulo 9 pre-existing failures on `next` (missing `pypdfium2` in local env + a couple of golden-fixture regexes + an unrelated gvision attribute).

## Summary

Two structural cleanups from outside 1.0 review (posted in the thread), addressed together because they touch the same surface:

### 1. Library API moved out of `__main__.py`

- Before: importing `invoice2data` pulled in `click` + the CLI's ANSI/log-formatter plumbing, all from a 927-line `__main__.py` mixing library and CLI concerns.
- After: `extract_data`, `Invoice2Data`, the backend-cascade helpers (`_resolve_readers`, `_safe_to_text`, `_match_template`, `_by_priority`, `_line_items_missing`, `_preferred_module`, `_run_template`, `_ocr_last_resort`, `_ai_last_resort`, `_sample_text`), and `DEFAULT_INPUT_READERS` live in a new `invoice2data.api` module. `__main__` is now a thin click shell.
- `__init__.py` re-exports from `api`.
- `__main__.py` re-exports the moved names so pre-refactor callers (`from invoice2data.__main__ import extract_data`) keep working.
- Verified via `sys.modules`: `import invoice2data` no longer pulls in `click`.

### 2. Assert-based validation replaced with typed errors

Asserts vanish under `python -O` and expose `AssertionError` -- an internal invariant class -- to library callers. Add `TemplateSyntaxError(InvoiceProcessingError, ValueError)` and convert the user-facing sites:

| File | Site | Before | After |
|------|------|--------|-------|
| `invoice_template.parse_number` | non-string value | `assert isinstance(value, str)` | `TypeError` (internal invariant, hot path) |
| `invoice_template.parse_number` | decimal_separator not str | `assert isinstance(...)` | `TemplateSyntaxError` |
| `invoice_template.parse_number` | separator appears twice | `assert count < 2, ...` | `TemplateSyntaxError` |
| `invoice_template.coerce_type` | unknown `type:` | `raise AssertionError("Unknown type")` | `TemplateSyntaxError` |
| `invoice_template.prepare_input` | malformed `replace` pair | `assert len(replace) == 2, ...` | `TemplateSyntaxError` |
| `extract.parsers.lines` | missing `line`/`start`/`end` | `assert ... in settings, ...` | `TemplateSyntaxError` |
| `extract.plugins.tables` | missing `start`/`end`/`body` | `assert key in table, ...` | `TemplateSyntaxError` |

`TemplateSyntaxError` subclasses `ValueError` so the cascade's existing `except ValueError` retry keeps skipping broken templates gracefully.

**Follow-up:** the area-detail asserts in the input backends (`pdfium.py`, `pdftotext.py`, `tesseract.py`) are also user-facing (template author forgot area coord keys) but cross more file boundaries. Left as a separate PR to keep this one review-sized.

## Diff shape

- `src/invoice2data/api.py` — new, holds moved code
- `src/invoice2data/__main__.py` — 927 → 516 lines (API removed, re-exports added)
- `src/invoice2data/__init__.py` — re-export from `api` (+ new `TemplateSyntaxError`)
- `src/invoice2data/exceptions.py` — add `TemplateSyntaxError`
- `src/invoice2data/extract/invoice_template.py` — 4 assert conversions
- `src/invoice2data/extract/parsers/lines.py` — 3 assert conversions
- `src/invoice2data/extract/plugins/tables.py` — 1 assert conversion
- `tests/test_main_helpers.py` — 1 monkeypatch target update (`invoice2data.__main__.is_available` → `invoice2data.api.is_available`, since that's where `_preferred_module` now closes over the symbol)

## Test plan

- [x] `pytest --ignore=tests/compare` — 275 passing, 9 pre-existing failures (identical on unstashed `next`)
- [x] `python -c "import sys; import invoice2data; assert 'click' not in sys.modules"` -- passes
- [x] `python -c "from invoice2data.__main__ import extract_data; from invoice2data.api import extract_data; assert extract_data is extract_data"` -- old + new import paths yield the same function
- [ ] CI matrix