### PR TITLE
refactor(input): `TemplateSyntaxError` for missing area-block keys

### DIFF
--- a/src/invoice2data/exceptions.py
+++ b/src/invoice2data/exceptions.py
@@ -41,3 +41,28 @@ class RequiredFieldsMissingError(InvoiceProcessingError, ValueError):
         if template_name:
             message += f" (template {template_name})"
         super().__init__(message)
+
+
+class TemplateSyntaxError(InvoiceProcessingError, ValueError):
+    """A template's configuration is malformed (author-side error).
+
+    Raised when a template's ``area`` block is missing required keys.
+    Replaces the ``AssertionError`` raised by pre-1.x versions -- asserts
+    silently vanish under ``python -O`` and expose an internal invariant
+    class to library callers. Subclasses :class:`ValueError` so the
+    input-backend cascade's existing ``except ValueError`` retry handling
+    continues to skip a broken template gracefully.
+
+    Args:
+        message (str): Human-readable description of what is wrong.
+        template_name (str | None): The offending template's name, when known.
+
+    Attributes:
+        template_name (str | None): The offending template, when known.
+    """
+
+    def __init__(self, message: str, template_name: str | None = None) -> None:
+        self.template_name = template_name
+        if template_name:
+            message = f"{message} (template {template_name})"
+        super().__init__(message)

--- a/src/invoice2data/input/pdfium.py
+++ b/src/invoice2data/input/pdfium.py
@@ -11,6 +11,8 @@ so an area template targets one backend's text, not both.
 from logging import getLogger
 from typing import Any
 
+from ..exceptions import TemplateSyntaxError
+
 
 logger = getLogger(__name__)
 
@@ -75,9 +77,16 @@ def _crop_pages(document: Any, area: dict[str, Any]) -> list[str]:
 
     Returns:
         list[str]: The cropped text, one entry per page in the range.
+
+    Raises:
+        TemplateSyntaxError: If ``area`` is missing any of the required keys.
     """
     for key in ("f", "l", "r", "x", "y", "W", "H"):
-        assert key in area, f"Area {key} details missing"
+        if key not in area:
+            raise TemplateSyntaxError(
+                f"template `area` block missing required key `{key}` "
+                "(need f, l, r, x, y, W, H)"
+            )
     first, last = int(area["f"]), int(area["l"])
     factor = 72.0 / float(area["r"])
     x, y = float(area["x"]), float(area["y"])

--- a/src/invoice2data/input/pdftotext.py
+++ b/src/invoice2data/input/pdftotext.py
@@ -13,6 +13,8 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
+from ..exceptions import TemplateSyntaxError
+
 
 SUPPORTS_AREA = True
 
@@ -169,7 +171,11 @@ def to_text(path: str, area_details: dict[str, Any] | None = None) -> str:
 
     if area_details is not None:
         for key in ("f", "l", "r", "x", "y", "W", "H"):
-            assert key in area_details, f"Area {key} details missing"
+            if key not in area_details:
+                raise TemplateSyntaxError(
+                    f"template `area` block missing required key `{key}` "
+                    "(need f, l, r, x, y, W, H)"
+                )
         # Crop from the cached word positions -- one parse per file regardless of
         # how many area fields a template defines.
         return _crop(_words(path, _mtime(path)), area_details)

--- a/src/invoice2data/input/tesseract.py
+++ b/src/invoice2data/input/tesseract.py
@@ -13,6 +13,8 @@ from subprocess import TimeoutExpired
 from subprocess import run
 from typing import Any
 
+from ..exceptions import TemplateSyntaxError
+
 
 logger = getLogger(__name__)
 
@@ -46,6 +48,23 @@ def is_available() -> bool:
             (``magick`` or the legacy ``convert``) are on the PATH.
     """
     return shutil.which("tesseract") is not None and _imagemagick_cmd() is not None
+
+
+def _validate_area_details(area_details: dict[str, Any]) -> None:
+    """Raise ``TemplateSyntaxError`` if a required area key is missing.
+
+    Args:
+        area_details (dict[str, Any]): The template's ``area`` block.
+
+    Raises:
+        TemplateSyntaxError: If any of ``f, l, r, x, y, W, H`` is absent.
+    """
+    for key in ("f", "l", "r", "x", "y", "W", "H"):
+        if key not in area_details:
+            raise TemplateSyntaxError(
+                f"template `area` block missing required key `{key}` "
+                "(need f, l, r, x, y, W, H)"
+            )
 
 
 def to_text(path: str, area_details: dict[str, Any] | None = None) -> str:
@@ -149,15 +168,7 @@ def to_text(path: str, area_details: dict[str, Any] | None = None) -> str:
         "UTF-8",
     ]
     if area_details is not None:
-        # An area was specified
-        # Validate the required keys were provided
-        assert "f" in area_details, "Area r details missing"
-        assert "l" in area_details, "Area r details missing"
-        assert "r" in area_details, "Area r details missing"
-        assert "x" in area_details, "Area x details missing"
-        assert "y" in area_details, "Area y details missing"
-        assert "W" in area_details, "Area W details missing"
-        assert "H" in area_details, "Area H details missing"
+        _validate_area_details(area_details)
         # Convert all of the values to strings
         for key in area_details:
             area_details[key] = str(area_details[key])

--- a/tests/test_area_extraction.py
+++ b/tests/test_area_extraction.py
@@ -62,3 +62,23 @@ def test_pdfium_area_extraction() -> None:
     assert "PAYMENT RECEIPT" in top  # header inside the band
     assert "31/12/2017" in top
     assert "OYO" not in top  # excluded by the top-band crop
+
+
+def test_pdftotext_missing_area_key_raises_template_syntax_error() -> None:
+    """Bad area block used to `AssertionError`; now raises `TemplateSyntaxError`."""
+    from invoice2data.exceptions import TemplateSyntaxError
+
+    incomplete_area = {"f": 1, "l": 1, "r": 300}  # missing x, y, W, H
+    with pytest.raises(TemplateSyntaxError, match="missing required key"):
+        pdftotext.to_text(OYO, incomplete_area)
+
+
+def test_pdfium_missing_area_key_raises_template_syntax_error() -> None:
+    """Bad area block used to `AssertionError`; now raises `TemplateSyntaxError`."""
+    pytest.importorskip("pypdfium2")
+    from invoice2data.exceptions import TemplateSyntaxError
+    from invoice2data.input import pdfium
+
+    incomplete_area = {"f": 1, "l": 1, "r": 300}  # missing x, y, W, H
+    with pytest.raises(TemplateSyntaxError, match="missing required key"):
+        pdfium.to_text(OYO, incomplete_area)

--- a/tests/test_tesseract.py
+++ b/tests/test_tesseract.py
@@ -165,6 +165,22 @@ def test_to_text_with_area_details(
     assert "600" in pdftotext_cmd  # area values are stringified into the command
 
 
+def test_to_text_missing_area_key_raises_template_syntax_error(
+    tmp_path: Path,
+    mocker: "pytest_mock.MockerFixture",  # type: ignore[name-defined]  # noqa
+) -> None:
+    """Bad area block used to `AssertionError`; now raises `TemplateSyntaxError`."""
+    from invoice2data.exceptions import TemplateSyntaxError
+
+    pdf = tmp_path / "invoice.pdf"
+    pdf.write_bytes(b"%PDF-1.4")
+    _mock_pipeline(mocker)
+    incomplete_area = {"f": 1, "l": 1, "r": 100}  # missing x, y, W, H
+
+    with pytest.raises(TemplateSyntaxError, match="missing required key"):
+        tesseract.to_text(str(pdf), incomplete_area)
+
+
 def test_to_text_tesseract_timeout_still_returns(
     tmp_path: Path,
     mocker: "pytest_mock.MockerFixture",  # type: ignore[name-defined]  # noqa


### PR DESCRIPTION
## Summary

Follow-up to #725. The remaining user-facing asserts flagged in outside 1.0 review live in the input-backend `to_text()` calls -- `pdfium.py`, `pdftotext.py`, `tesseract.py` -- validating that a template's `area` block declares all required keys (`f, l, r, x, y, W, H`). Same treatment as #725:

- Convert `assert key in area, "..."` → `raise TemplateSyntaxError(...)`.
- Error survives `python -O`, library callers see a typed exception (not `AssertionError`), and the cascade's existing `except ValueError` retry (because `TemplateSyntaxError` subclasses `ValueError`) keeps skipping broken area templates gracefully.

`TemplateSyntaxError` is defined locally in `exceptions.py` (identical to the class added by #725). If #725 merges first, git will collapse the duplicate at merge time; if this lands first, #725's addition becomes a no-op. Either order works.

## Diff shape

- `src/invoice2data/exceptions.py` -- add `TemplateSyntaxError` (identical to #725; harmless duplicate)
- `src/invoice2data/input/pdfium.py` -- 1 assert converted
- `src/invoice2data/input/pdftotext.py` -- 1 assert converted
- `src/invoice2data/input/tesseract.py` -- 7 asserts collapsed into 1 loop
- `tests/test_area_extraction.py` -- 2 new tests (pdftotext + pdfium, real PDF fixture)
- `tests/test_tesseract.py` -- 1 new test (mocked OCR binaries)

## Test plan

- [x] `pytest tests/test_area_extraction.py tests/test_tesseract.py` -- 22 passing, 2 skipped
- [x] full suite: only the 9 pre-existing failures on master (unrelated -- pypdfium2 not in local env, gvision attribute drift, date-regex miss)
- [ ] CI