### PR TITLE
ci: add OSS-Fuzz harnesses (Atheris) + submission templates

### DIFF
--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -1,0 +1,50 @@
+# Fuzz targets
+
+Continuous fuzzing via [OSS-Fuzz](https://google.github.io/oss-fuzz/). This
+directory ships the [Atheris](https://github.com/google/atheris)-based
+harnesses invoice2data exposes to OSS-Fuzz's build system.
+
+## What each harness covers
+
+| Harness | Target |
+|---------|--------|
+| `fuzz_parse_number.py` | `InvoiceTemplate.parse_number` -- locale / separator edge cases |
+| `fuzz_parse_date.py` | `InvoiceTemplate.parse_date` -- format + language matrix |
+| `fuzz_ordered_load.py` | `ordered_load` (stream loader) on both JSON + YAML payloads |
+| `fuzz_regex_compile.py` | `regex.compile` on user-supplied template patterns (ReDoS guard) |
+
+Same crash class the in-repo property tests (`tests/test_property.py`,
+`hypothesis`) exercise -- OSS-Fuzz runs them continuously on Google's
+infrastructure, catches the long-tail cases the ~500 hypothesis examples
+per CI run miss, and lands corpus regressions as GitHub issues via the
+OSS-Fuzz issue-tracker integration.
+
+## Running locally
+
+```bash
+uv sync --group dev --extra ai --extra dateparser
+pip install atheris
+
+# 30-second smoke run
+python fuzz/fuzz_parse_number.py -atheris_runs=100000
+
+# Longer campaign with a corpus dir
+mkdir -p /tmp/i2d-corpus
+python fuzz/fuzz_ordered_load.py /tmp/i2d-corpus -runs=-1
+```
+
+## OSS-Fuzz project files
+
+Templates for the PR that lands in
+[`google/oss-fuzz/projects/invoice2data/`](https://github.com/google/oss-fuzz/tree/master/projects)
+live under [`oss-fuzz/`](./oss-fuzz/). Copy them into a fork of
+google/oss-fuzz, adjust the emails/URLs, and open the intake PR -- the OSS-Fuzz
+team usually reviews within a week.
+
+## Contract each harness enforces
+
+Every harness catches the *typed* failure modes
+(`invoice2data.exceptions.InvoiceProcessingError` and `ValueError`) so
+they don't count as findings. Any other exception is a real bug: the
+library's contract with callers is that parser inputs either return
+sensible failure values or raise a typed error class.

--- a/fuzz/fuzz_ordered_load.py
+++ b/fuzz/fuzz_ordered_load.py
@@ -1,0 +1,44 @@
+"""OSS-Fuzz harness for `invoice2data.extract.loader.ordered_load`.
+
+`ordered_load` accepts an untrusted string (from a DB column or API payload)
+and returns `list[InvoiceTemplate]` -- empty list on parse error. Every
+crash class here maps to a real ingest bug: the two initial hypothesis
+findings (int/None returning from `json.loads` / `yaml.safe_load` -> loader
+iterating a non-list) are already patched; OSS-Fuzz keeps looking for the
+long-tail cases.
+"""
+
+import sys
+
+import atheris
+
+
+with atheris.instrument_imports():
+    import yaml  # type: ignore[import-untyped]
+
+    from invoice2data.extract.loader import ordered_load
+
+
+def TestOneInput(data: bytes) -> None:  # noqa: N802
+    fdp = atheris.FuzzedDataProvider(data)
+    # First byte picks JSON vs YAML, rest is the payload.
+    kind = fdp.ConsumeIntInRange(0, 1)
+    payload = fdp.ConsumeUnicodeNoSurrogates(1024)
+    loader = yaml.safe_load if kind else None  # `None` -> default json.loads
+    if loader is None:
+        result = ordered_load(payload)
+    else:
+        result = ordered_load(payload, loader=loader)
+    # Contract: always a list, never propagates the parser's exception.
+    assert isinstance(result, list), (
+        f"ordered_load returned {type(result).__name__}, expected list"
+    )
+
+
+def main() -> None:
+    atheris.Setup(sys.argv, TestOneInput)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()

--- a/fuzz/fuzz_parse_date.py
+++ b/fuzz/fuzz_parse_date.py
@@ -1,0 +1,55 @@
+"""OSS-Fuzz harness for `InvoiceTemplate.parse_date`.
+
+`parse_date` walks a fastest-first cascade (stdlib `strptime` -> `dateutil`
+-> optional `dateparser`) with locale-dependent format strings. It must
+return a datetime, a date, or `None` -- never propagate an unexpected
+exception class.
+"""
+
+import sys
+
+import atheris
+
+
+with atheris.instrument_imports():
+    from invoice2data.exceptions import InvoiceProcessingError
+    from invoice2data.extract.invoice_template import InvoiceTemplate
+
+
+_TEMPLATE = InvoiceTemplate(
+    {
+        "template_name": "fuzz.yml",
+        "keywords": ["Anything"],
+        "exclude_keywords": [],
+        "options": {
+            "currency": "EUR",
+            "decimal_separator": ".",
+            "date_formats": [],
+            "languages": ["en"],
+            "replace": [],
+        },
+    }
+)
+
+
+def TestOneInput(data: bytes) -> None:  # noqa: N802
+    fdp = atheris.FuzzedDataProvider(data)
+    value = fdp.ConsumeUnicodeNoSurrogates(96)
+    try:
+        result = _TEMPLATE.parse_date(value)
+    except InvoiceProcessingError:
+        return
+    else:
+        # None or a date-like are the only allowed happy paths.
+        assert result is None or hasattr(result, "year"), (
+            f"parse_date returned {type(result).__name__}, expected date-like or None"
+        )
+
+
+def main() -> None:
+    atheris.Setup(sys.argv, TestOneInput)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()

--- a/fuzz/fuzz_parse_number.py
+++ b/fuzz/fuzz_parse_number.py
@@ -1,0 +1,51 @@
+"""OSS-Fuzz harness for `InvoiceTemplate.parse_number`.
+
+Locale-dependent number parsing is a classic crash surface. The library
+contract: the parser returns a float, or raises a ValueError-subclass typed
+error. Any other exception class is a real bug.
+"""
+
+import sys
+
+import atheris
+
+
+with atheris.instrument_imports():
+    from invoice2data.exceptions import InvoiceProcessingError
+    from invoice2data.extract.invoice_template import InvoiceTemplate
+
+
+_TEMPLATE = InvoiceTemplate(
+    {
+        "template_name": "fuzz.yml",
+        "keywords": ["Anything"],
+        "exclude_keywords": [],
+        "options": {
+            "currency": "EUR",
+            "decimal_separator": ".",
+            "date_formats": [],
+            "languages": ["en"],
+            "replace": [],
+        },
+    }
+)
+
+
+def TestOneInput(data: bytes) -> None:  # noqa: N802 (Atheris harness convention)
+    """Fuzz entry point. See module docstring for the contract."""
+    fdp = atheris.FuzzedDataProvider(data)
+    # Cap the input size so the fuzzer spends time on shape variety, not size.
+    value = fdp.ConsumeUnicodeNoSurrogates(64)
+    try:
+        _TEMPLATE.parse_number(value)
+    except (ValueError, InvoiceProcessingError):
+        return  # documented failure mode
+
+
+def main() -> None:
+    atheris.Setup(sys.argv, TestOneInput)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()

--- a/fuzz/fuzz_regex_compile.py
+++ b/fuzz/fuzz_regex_compile.py
@@ -1,0 +1,42 @@
+"""OSS-Fuzz harness for the `regex` engine on user-supplied template patterns.
+
+Templates ship arbitrary regex patterns via the ``regex`` / ``lines`` /
+``tables`` field parsers. The `regex` library rejects some pathological
+patterns outright (`regex.error`); anything else is either a compile-time
+crash we should surface, or a runtime hang the fuzzer will detect via the
+libFuzzer timeout.
+"""
+
+import sys
+
+import atheris
+
+
+with atheris.instrument_imports():
+    import regex  # type: ignore[import-untyped]
+
+
+def TestOneInput(data: bytes) -> None:  # noqa: N802
+    fdp = atheris.FuzzedDataProvider(data)
+    pattern = fdp.ConsumeUnicodeNoSurrogates(128)
+    try:
+        compiled = regex.compile(pattern)
+    except (regex.error, ValueError, RecursionError):
+        return  # documented failure modes for hostile patterns
+
+    # Also exercise the matching path on a bounded body -- ReDoS shows up
+    # here, not at compile time. libFuzzer's `-timeout` flag catches hangs.
+    body = fdp.ConsumeUnicodeNoSurrogates(256)
+    try:
+        compiled.search(body)
+    except (regex.error, ValueError):
+        return
+
+
+def main() -> None:
+    atheris.Setup(sys.argv, TestOneInput)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()

--- a/fuzz/oss-fuzz/Dockerfile.example
+++ b/fuzz/oss-fuzz/Dockerfile.example
@@ -1,0 +1,8 @@
+# Submit this (renamed to `Dockerfile`) inside
+# `google/oss-fuzz/projects/invoice2data/` alongside `project.yaml`.
+# See https://google.github.io/oss-fuzz/getting-started/new-project-guide/python-lang/#dockerfile
+
+FROM gcr.io/oss-fuzz-base/base-builder-python
+RUN git clone --depth 1 https://github.com/invoice-x/invoice2data $SRC/invoice2data
+WORKDIR $SRC/invoice2data
+COPY build.sh $SRC/

--- a/fuzz/oss-fuzz/build.sh.example
+++ b/fuzz/oss-fuzz/build.sh.example
@@ -1,0 +1,18 @@
+#!/bin/bash -eu
+# Submit this (renamed to `build.sh`) inside
+# `google/oss-fuzz/projects/invoice2data/` alongside `project.yaml` and
+# `Dockerfile`. Runs inside the OSS-Fuzz base-builder-python container.
+#
+# See https://google.github.io/oss-fuzz/getting-started/new-project-guide/python-lang/#buildsh
+
+# Install invoice2data + the extras a couple of harnesses touch.
+# `--no-deps` after so mypyc compilation of the wheel isn't triggered inside
+# the sanitizer build; the fuzzer runs pure-Python.
+pip3 install --upgrade pip
+pip3 install "$SRC/invoice2data"
+pip3 install atheris pyyaml regex
+
+# Build each harness. OSS-Fuzz's `compile_python_fuzzer` wraps Atheris.
+for fuzzer in "$SRC/invoice2data/fuzz/fuzz_"*.py; do
+  compile_python_fuzzer "$fuzzer"
+done

--- a/fuzz/oss-fuzz/project.yaml.example
+++ b/fuzz/oss-fuzz/project.yaml.example
@@ -1,0 +1,19 @@
+# Submit this (renamed to `project.yaml`) inside
+# `google/oss-fuzz/projects/invoice2data/` via a PR to google/oss-fuzz.
+# See https://google.github.io/oss-fuzz/getting-started/new-project-guide/
+# and https://google.github.io/oss-fuzz/getting-started/new-project-guide/python-lang/
+
+homepage: "https://github.com/invoice-x/invoice2data"
+language: python
+primary_contact: "REPLACE_WITH_YOUR_EMAIL@example.com"
+auto_ccs:
+  - "REPLACE_WITH_ADDITIONAL_MAINTAINER@example.com"
+main_repo: "https://github.com/invoice-x/invoice2data"
+sanitizers:
+  - address
+  - undefined
+fuzzing_engines:
+  - libfuzzer
+architectures:
+  - x86_64
+file_github_issue: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -293,5 +293,5 @@ convention = "google"
 
 [tool.pydoclint]
 style = 'google'
-exclude = '\.git|\.nox|tests*|noxfile.py|tables.py'
+exclude = '\.git|\.nox|tests*|noxfile.py|tables.py|fuzz/'
 arg-type-hints-in-docstring = true


### PR DESCRIPTION
## Summary

Companion to #728 (hypothesis property tests). Same crash class from a different direction: hypothesis runs ~500 examples per CI run; OSS-Fuzz runs continuously on Google's infrastructure and files GitHub issues for the long-tail cases the ~500 examples miss.

**Four Atheris harnesses**, all exercising a typed-error contract (parser may raise `InvoiceProcessingError` / `ValueError` — anything else is a bug):

| Harness | Target |
|---------|--------|
| `fuzz_parse_number.py` | `InvoiceTemplate.parse_number` — locale/separator edges |
| `fuzz_parse_date.py`   | `InvoiceTemplate.parse_date` — format+language matrix |
| `fuzz_ordered_load.py` | Stream loader on both JSON + YAML payloads |
| `fuzz_regex_compile.py`| `regex.compile` + `search` — libFuzzer `-timeout` catches ReDoS |

`fuzz/oss-fuzz/*.example` are the templates for the intake PR that lands in [`google/oss-fuzz/projects/invoice2data/`](https://github.com/google/oss-fuzz/tree/master/projects). Rename to drop `.example`, adjust email/URLs, submit.

## Background context

Revives #543 (OSS-Fuzz offer from Dec 2023, stalled when @ennamarie19 went silent after email exchange). This PR does self-integration steps 2 and 3 from the strategy I proposed on that issue — hypothesis in #728 gets us most of the crash-finding value on every CI run; OSS-Fuzz on top gets the security-posture signal + continuous long-running fuzz.

## Test plan

- [x] `ruff check fuzz/` — clean
- [x] `ruff format --check fuzz/` — clean
- [x] pydoclint exclude extended to `fuzz/` (harnesses are single-purpose scripts, don't need google-style docstrings)
- [x] No mypy scope change needed: nox `mypy` session targets `src`/`tests`/`docs/conf.py` explicitly
- [ ] Local smoke run: `pip install atheris && python fuzz/fuzz_parse_number.py -atheris_runs=100000`
- [ ] Follow-up (external): PR to `google/oss-fuzz` adding `projects/invoice2data/` from the `fuzz/oss-fuzz/*.example` files

## Follow-up

- Submit the `google/oss-fuzz` intake PR (external, ~1 week review)
- Wire OSS-Fuzz's issue-tracker integration so findings land as GitHub issues
- Consider whether to also fuzz `read_templates` on a directory of random files (needs a Dockerfile mount, done by OSS-Fuzz corpus mgmt)