### PR TITLE
chore(docs): Decrement level of chapter 'Lines'

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -230,7 +230,7 @@ If the first regexp for `VAT 10%` catches **1.5** and the second regexp for
 As you can see, the sum_ prefix is removed from the amount_tax field name.
 
 
-### Lines
+#### Lines
 
 The `lines` key allows you to extract line item data from invoices, such as product descriptions, quantities, and prices.
 


### PR DESCRIPTION
Based on [Parser lines](https://invoice2data.readthedocs.io/latest/tutorial.html#parser-lines), the [Lines](https://invoice2data.readthedocs.io/latest/tutorial.html#lines) plugin is deprecated and the code also signals this to the user.

The current version of the docs implies by structure, [Lines](https://invoice2data.readthedocs.io/latest/tutorial.html#lines) is on the same level as [Parser lines](https://invoice2data.readthedocs.io/latest/tutorial.html#parser-lines) and especially [Legacy Regexes](https://invoice2data.readthedocs.io/latest/tutorial.html#legacy-regexes), that this is not deprecated. Also, [Lines](https://invoice2data.readthedocs.io/latest/tutorial.html#lines) doesn't mention it's deprecated.

I propose decrementing the level of [Lines](https://invoice2data.readthedocs.io/latest/tutorial.html#lines), such that it appears **below** [Legacy Regexes](https://invoice2data.readthedocs.io/latest/tutorial.html#legacy-regexes), implying it's deprecation automatically.

---

I ran into the issue, because I contemplated [Lines](https://invoice2data.readthedocs.io/latest/tutorial.html#lines) equal to the rest of the possibilities (or I forgot the deprecation warning in [Parser lines](https://invoice2data.readthedocs.io/latest/tutorial.html#parser-lines)).