### PR TITLE
fix(nox): use list for `nox.options.sessions` (nox 2026.8.10 type tightening)

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -15,7 +15,7 @@ nox.options.default_venv_backend = "uv"
 package = "invoice2data"
 python_versions = ["3.13", "3.12", "3.11", "3.10"]
 nox.needs_version = ">= 2021.6.6"
-nox.options.sessions = (
+nox.options.sessions = [
     "pre-commit",
     "pip-audit",  # replaced `safety` — pypa/pip-audit needs no auth
     "mypy",
@@ -24,7 +24,7 @@ nox.options.sessions = (
     "typeguard",
     "xdoctest",
     "docs-build",
-)
+]
 
 
 def activate_virtualenv_in_precommit_hooks(session: nox.Session) -> None:


### PR DESCRIPTION
## Summary

nox 2026.8.10 (released 2026-08-10) tightened the annotation of \`nox.options.sessions\` from \`Iterable[str]\` to \`list[str] | None\`. Our noxfile has always used a tuple, which the old stubs accepted:

\`\`\`
noxfile.py:18: error: Incompatible types in assignment
(expression has type "tuple[str, ...]",
 variable has type "list[str] | None")  [assignment]
\`\`\`

Every CI run since the nox release fails on this. Currently visible on all four open dependabot PRs (#738-#741) but affects any push / re-run. Master's last run predates the release so still cached green.

**Fix:** tuple parens → list brackets. Behaviour unchanged; runtime still accepts either since nox iterates it.

## Test plan

- [x] Diff: one-line semantic change
- [ ] CI: mypy 3.10 + 3.13 both green