### PR TITLE
feat: add record values to lines and camelot

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -300,6 +300,35 @@ If a line matches `first_line`, it starts a new item. If it matches `last_line`,
 When using `first_line` and `last_line`, make sure that `first_line` is the most specific regex and `line` is the least specific.
 ````
 
+#### Static values and defaults per record
+
+The `lines` parser produces a list of records. Use `static` for values that
+belong on every extracted record, and `defaults` to fill a missing or empty
+capture. This avoids adding artificial capture groups for values that are known
+from the template:
+
+```yaml
+fields:
+  lines:
+    parser: lines
+    start: 'Item'
+    end: 'Total'
+    line: '(?P<name>.+)\s+(?P<price_subtotal>\d+[.,]\d{2})'
+    static:
+      taxes:
+        - amount: 21.0
+    defaults:
+      qty: 1
+```
+
+For templates migrated from the legacy top-level `lines:` plugin,
+`static_<field>` and `<field>_default` remain accepted inside the modern
+`lines` field. `no_newline_fields: [name]` suppresses the newline normally
+inserted when continuation captures are combined. `append_on_line: true` is an
+explicit compatibility mode for layouts where every `line` match completes the
+current item; it is off by default because multi-line descriptions normally
+need to be combined.
+
 #### Recipes & troubleshooting
 
 Most line-parsing problems come down to one of two things: the text

--- a/src/invoice2data/extract/parsers/lines.py
+++ b/src/invoice2data/extract/parsers/lines.py
@@ -12,6 +12,7 @@ from ...exceptions import TemplateSyntaxError
 from .. import _regex
 from .regex import _normalize_replacements
 from .regex import _replace_value
+from .records import apply_static_and_defaults
 
 
 if TYPE_CHECKING:
@@ -143,7 +144,9 @@ def parse_block(  # noqa: RUF100 C901
                     # This is the last_line, so parse all lines thus far,
                     # append to output,
                     # and reset current_row
-                    current_row = parse_current_row(match, current_row)
+                    current_row = parse_current_row(
+                        match, current_row, settings.get("no_newline_fields", ())
+                    )
                     if current_row:
                         lines.append(current_row)
                     current_row = {}
@@ -155,7 +158,14 @@ def parse_block(  # noqa: RUF100 C901
             if match:
                 # This is one of the lines between first_line and last_line
                 # Parse the data and add it to the current_row
-                current_row = parse_current_row(match, current_row)
+                current_row = parse_current_row(
+                    match, current_row, settings.get("no_newline_fields", ())
+                )
+                if settings.get("append_on_line"):
+                    if current_row:
+                        lines.append(current_row)
+                    current_row = {}
+                    first_line_found = False
                 continue
         # If the line doesn't match anything, log and continue to next line
         logger.debug("The following line doesn't match anything:\n*%s*", line)
@@ -170,7 +180,7 @@ def parse_block(  # noqa: RUF100 C901
         for name in row:
             if name in types:
                 row[name] = template.coerce_type(row[name], types[name])
-    return lines
+    return apply_static_and_defaults(lines, settings)
 
 
 def _normalize_line_replace(spec: Any) -> dict[str, list[tuple[str, str]]]:
@@ -318,7 +328,12 @@ def parse(
     """
     if "rules" in settings:
         # One field can have multiple sets of line-parsing rules
-        rules = settings["rules"]
+        common = {
+            key: value
+            for key, value in settings.items()
+            if key not in {"parser", "rules"}
+        }
+        rules = [{**common, **rule} for rule in settings["rules"]]
     else:
         # Original syntax stored line-parsing rules in top field YAML object
         keys = (
@@ -330,8 +345,20 @@ def parse(
             "last_line",
             "skip_line",
             "types",
+            "line_separator",
+            "replace",
+            "static",
+            "defaults",
+            "no_newline_fields",
+            "append_on_line",
         )
-        rules = [{k: v for k, v in settings.items() if k in keys}]
+        rules = [
+            {
+                k: v
+                for k, v in settings.items()
+                if k in keys or k.startswith("static_") or k.endswith("_default")
+            }
+        ]
 
     lines = []
     for i, rule in enumerate(rules):
@@ -344,7 +371,9 @@ def parse(
 
 
 def parse_current_row(
-    match: Match[str] | None, current_row: dict[str, Any]
+    match: Match[str] | None,
+    current_row: dict[str, Any],
+    no_newline_fields: tuple[str, ...] | list[str] = (),
 ) -> dict[str, Any]:
     """Parse the current row data.
 
@@ -357,9 +386,10 @@ def parse_current_row(
     """
     if match:
         for field, value in match.groupdict().items():
+            separator = "" if field in no_newline_fields else "\n"
             current_row[field] = "%s%s%s" % (
                 current_row.get(field, ""),
-                (current_row.get(field, "") and "\n") or "",
+                (current_row.get(field, "") and separator) or "",
                 value.strip() if value else "",
             )
     return current_row

--- a/src/invoice2data/extract/parsers/lines.py
+++ b/src/invoice2data/extract/parsers/lines.py
@@ -10,9 +10,9 @@ from typing import Any
 
 from ...exceptions import TemplateSyntaxError
 from .. import _regex
+from .records import apply_static_and_defaults
 from .regex import _normalize_replacements
 from .regex import _replace_value
-from .records import apply_static_and_defaults
 
 
 if TYPE_CHECKING:
@@ -375,11 +375,14 @@ def parse_current_row(
     current_row: dict[str, Any],
     no_newline_fields: tuple[str, ...] | list[str] = (),
 ) -> dict[str, Any]:
-    """Parse the current row data.
+    r"""Parse the current row data.
 
     Args:
         match (Match[str] | None): The match object.
         current_row (dict[str, Any]): The current row dictionary.
+        no_newline_fields (tuple[str, ...] | list[str]): Field names whose
+            continuation captures should be concatenated without the default
+            ``\n`` separator. Defaults to ``()``.
 
     Returns:
         dict[str, Any]: The updated current row dictionary.

--- a/src/invoice2data/extract/parsers/records.py
+++ b/src/invoice2data/extract/parsers/records.py
@@ -1,0 +1,37 @@
+"""Common post-processing for parsers that produce record dictionaries."""
+
+from typing import Any
+
+
+def apply_static_and_defaults(
+    records: list[dict[str, Any]], settings: dict[str, Any]
+) -> list[dict[str, Any]]:
+    """Apply declarative static values and fallbacks to each extracted record.
+
+    ``static`` and ``defaults`` are the preferred mapping forms.  The
+    ``static_<field>`` and ``<field>_default`` aliases are retained for
+    templates that predate the field-based lines parser.  Static values always
+    win; defaults only fill absent or empty values, matching the historic
+    lines-plugin behaviour.
+    """
+    static = {
+        key.removeprefix("static_"): value
+        for key, value in settings.items()
+        if key.startswith("static_")
+    }
+    static.update(settings.get("static", {}))
+
+    defaults = {
+        key.removesuffix("_default"): value
+        for key, value in settings.items()
+        if key.endswith("_default")
+    }
+    defaults.update(settings.get("defaults", {}))
+
+    for record in records:
+        for key, value in static.items():
+            record[key] = value
+        for key, value in defaults.items():
+            if not record.get(key):
+                record[key] = value
+    return records

--- a/src/invoice2data/extract/parsers/records.py
+++ b/src/invoice2data/extract/parsers/records.py
@@ -19,14 +19,17 @@ def apply_static_and_defaults(
         for key, value in settings.items()
         if key.startswith("static_")
     }
-    static.update(settings.get("static", {}))
+    # `settings.get("static") or {}` (not `.get("static", {})`) so a bare
+    # `static:` in YAML (parses to `None`) doesn't raise `TypeError` on the
+    # `.update(None)` below. Same for `defaults`.
+    static.update(settings.get("static") or {})
 
     defaults = {
         key.removesuffix("_default"): value
         for key, value in settings.items()
         if key.endswith("_default")
     }
-    defaults.update(settings.get("defaults", {}))
+    defaults.update(settings.get("defaults") or {})
 
     for record in records:
         for key, value in static.items():

--- a/src/invoice2data/extract/plugins/camelot.py
+++ b/src/invoice2data/extract/plugins/camelot.py
@@ -13,6 +13,8 @@ plugin-specific keys are:
     field   output key to populate (default: ``lines``)
     header  use the table's first row as the column names (default: ``true``)
     tables  which detected table to use: an index, or ``all`` (default: ``all``)
+    static  mapping of values to add to every extracted record
+    defaults mapping of values to fill when a record column is empty or absent
 
 Example::
 
@@ -24,6 +26,8 @@ Example::
 
 from logging import getLogger
 from typing import Any
+
+from ..parsers.records import apply_static_and_defaults
 
 
 logger = getLogger(__name__)
@@ -108,7 +112,8 @@ def extract(
         header = rule.pop("header", True)
         which = rule.pop("tables", "all")
         read_kwargs = {key: rule[key] for key in rule if key in _READ_PDF_KEYS}
-        unknown = set(rule) - _READ_PDF_KEYS
+        record_options = {"static", "defaults"}
+        unknown = set(rule) - _READ_PDF_KEYS - record_options
         if unknown:
             logger.warning("camelot: ignoring unknown option(s) %s", sorted(unknown))
 
@@ -122,6 +127,7 @@ def extract(
         records: list[dict[str, Any]] = []
         for table in selected:
             records.extend(_rows_to_records(table.data, header))
+        apply_static_and_defaults(records, rule)
         logger.debug("camelot extracted %d row(s) into '%s'", len(records), field)
         if records:
             output[field] = records

--- a/tests/test_camelot.py
+++ b/tests/test_camelot.py
@@ -147,6 +147,29 @@ def test_extract_skips_when_no_body_rows(
     assert output == {}
 
 
+def test_extract_applies_record_static_and_defaults(
+    mocker: "pytest_mock.MockerFixture",  # type: ignore[name-defined]  # noqa
+) -> None:
+    _fake_camelot(mocker, [_table([["name", "qty"], ["Widget", ""]])])
+    output: dict[str, Any] = {}
+    camelot.extract(
+        {
+            "template_name": "t",
+            "camelot": {
+                "field": "lines",
+                "static": {"taxes": [{"amount": 21.0}]},
+                "defaults": {"qty": 1},
+            },
+        },
+        "",
+        output,
+        "x.pdf",
+    )
+    assert output["lines"] == [
+        {"name": "Widget", "qty": 1, "taxes": [{"amount": 21.0}]}
+    ]
+
+
 def test_rows_to_records_empty() -> None:
     assert camelot._rows_to_records([], header=True) == []
 

--- a/tests/test_record_values.py
+++ b/tests/test_record_values.py
@@ -1,0 +1,98 @@
+"""Static values and defaults for record-producing extractors."""
+
+from typing import Any
+
+from invoice2data.extract.parsers import lines
+from invoice2data.extract.parsers.records import apply_static_and_defaults
+
+
+class _Template:
+    def coerce_type(self, value: Any, target: str) -> Any:
+        return value
+
+
+def test_static_and_defaults_preferred_mapping_forms() -> None:
+    records = [{"name": "Widget", "qty": ""}, {"name": "Service"}]
+    assert apply_static_and_defaults(
+        records,
+        {
+            "static": {"taxes": [{"amount": 21.0}]},
+            "defaults": {"qty": 1, "price_unit": 0},
+        },
+    ) == [
+        {"name": "Widget", "qty": 1, "taxes": [{"amount": 21.0}], "price_unit": 0},
+        {"name": "Service", "taxes": [{"amount": 21.0}], "qty": 1, "price_unit": 0},
+    ]
+
+
+def test_legacy_record_value_aliases_work_in_modern_lines_parser() -> None:
+    rows = lines.parse(
+        _Template(),  # type: ignore[arg-type]
+        "lines",
+        {
+            "parser": "lines",
+            "start": r"(?m)^Items$",
+            "end": r"(?m)^Total$",
+            "line": r"(?P<name>\w+)(?:\s+(?P<qty>\d+))?",
+            "static_taxes": [{"amount": 9.0}],
+            "qty_default": 1,
+        },
+        "Items\nCoffee 2\nShipping\nTotal\n",
+    )
+    assert rows == [
+        {"name": "Coffee", "qty": "2", "taxes": [{"amount": 9.0}]},
+        {"name": "Shipping", "qty": 1, "taxes": [{"amount": 9.0}]},
+    ]
+
+
+def test_modern_rules_inherit_record_values() -> None:
+    rows = lines.parse(
+        _Template(),  # type: ignore[arg-type]
+        "lines",
+        {
+            "parser": "lines",
+            "static": {"taxes": [{"amount": 21.0}]},
+            "defaults": {"qty": 1},
+            "rules": [
+                {
+                    "start": r"(?m)^Items$",
+                    "end": r"(?m)^Total$",
+                    "line": r"(?P<name>\w+)",
+                }
+            ],
+        },
+        "Items\nService\nTotal\n",
+    )
+    assert rows == [{"name": "Service", "taxes": [{"amount": 21.0}], "qty": 1}]
+
+
+def test_no_newline_and_append_on_line_are_opt_in_lines_options() -> None:
+    rows = lines.parse_block(
+        _Template(),  # type: ignore[arg-type]
+        "lines",
+        {
+            "first_line": r"ITEM (?P<name>\w+)",
+            "line": r"QTY (?P<qty>\d+)",
+            "line_separator": r"\n",
+            "no_newline_fields": ["name"],
+            "append_on_line": True,
+        },
+        "ITEM One\nQTY 1\nITEM Two\nQTY 2\n",
+    )
+    assert rows == [{"name": "One", "qty": "1"}, {"name": "Two", "qty": "2"}]
+
+
+def test_no_newline_fields_concatenates_selected_continuations() -> None:
+    rows = lines.parse_block(
+        _Template(),  # type: ignore[arg-type]
+        "lines",
+        {
+            "first_line": r"ITEM (?P<name>\w+)",
+            "line": r"MORE (?P<name>\w+)",
+            "last_line": r"QTY (?P<qty>\d+)",
+            "line_separator": r"\n",
+            "no_newline_fields": ["name"],
+        },
+        "ITEM One\nMORE Extra\nQTY 1\n",
+    )
+    assert rows == [{"name": "OneExtra", "qty": "1"}]

--- a/tests/test_record_values.py
+++ b/tests/test_record_values.py
@@ -96,3 +96,15 @@ def test_no_newline_fields_concatenates_selected_continuations() -> None:
         "ITEM One\nMORE Extra\nQTY 1\n",
     )
     assert rows == [{"name": "OneExtra", "qty": "1"}]
+
+
+def test_bare_static_and_defaults_do_not_crash() -> None:
+    """`static:` / `defaults:` with no value parse to `None` in YAML.
+
+    The helper should treat that as an empty mapping, not raise ``TypeError``
+    from ``dict.update(None)``.
+    """
+    records = [{"name": "Widget"}]
+    assert apply_static_and_defaults(records, {"static": None, "defaults": None}) == [
+        {"name": "Widget"}
+    ]


### PR DESCRIPTION
## Summary

  Adds record-level `static` and `defaults` values to the modern `lines`
  parser and Camelot record output.

  - Keeps `static_<field>` and `<field>_default` as `lines` compatibility aliases.
  - Adds `no_newline_fields` and opt-in `append_on_line` to `lines`.
  - Does not add record semantics to scalar parsers or the legacy text tables plugin.

  ## Tests

  38 targeted tests passed, including lines, Camelot, tax lines and UNECE UoM.
