### PR TITLE
feat: support template page ranges

### DIFF
--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -208,7 +208,7 @@ this).
 ## "Only certain PDF pages are the invoice"
 
 Use a top-level inclusive `pages:` range. Unlike a field `area:`, this limits
-template keywords, document fields and line extraction together:
+template keywords, document fields, field areas and line extraction together:
 
 ```yaml
 issuer: Example supplier
@@ -220,7 +220,8 @@ fields:
   invoice_number: 'Invoice number\\s+(\\S+)'
 ```
 
-The range is one-based and inclusive. It is supported by `pdftotext` and
-`pdfium`; pin one of those readers when using it. Do not use `pages:` merely to
-hide a bad field regex: it is intended for real non-invoice pages such as a
-cover or envelope.
+The range is one-based and inclusive; use `pages: 2` when only page two is the
+invoice. All template keywords must occur within the selected pages. It is
+supported by `pdftotext` and `pdfium`; pin one of those readers when using it.
+Do not use `pages:` merely to hide a bad field regex: it is intended for real
+non-invoice pages such as a cover or envelope.

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -204,3 +204,23 @@ Backends that support area: `pdftotext` (native, uses `-x/-y/-W/-H`) and
 `pdfium` (in-process crop). For area-critical templates pin the backend with
 `input_module: pdftotext` at the top level (bundled area templates already do
 this).
+
+## "Only certain PDF pages are the invoice"
+
+Use a top-level inclusive `pages:` range. Unlike a field `area:`, this limits
+template keywords, document fields and line extraction together:
+
+```yaml
+issuer: Example supplier
+input_module: pdftotext
+pages: "2-3"
+keywords:
+  - Example supplier
+fields:
+  invoice_number: 'Invoice number\\s+(\\S+)'
+```
+
+The range is one-based and inclusive. It is supported by `pdftotext` and
+`pdfium`; pin one of those readers when using it. Do not use `pages:` merely to
+hide a bad field regex: it is intended for real non-invoice pages such as a
+cover or envelope.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -45,6 +45,11 @@ options:
   This also allows some flexibility as 'Company\s+(US|UK)' will match on both
   Company US and Company UK.
 - `exclude_keywords`: Optional. Regex patterns that, if matched, prevent the template from being used.
+- `pages`: Optional inclusive page range, such as `2-3`. It limits keyword
+  matching and all normal field extraction to that part of the PDF. Use it for
+  documents with cover, envelope or terms pages that must not influence the
+  invoice match. A page-scoped template needs a reader that supports it;
+  `pdftotext` and `pdfium` do.
 
 ## Fields & Parsers
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -45,11 +45,12 @@ options:
   This also allows some flexibility as 'Company\s+(US|UK)' will match on both
   Company US and Company UK.
 - `exclude_keywords`: Optional. Regex patterns that, if matched, prevent the template from being used.
-- `pages`: Optional inclusive page range, such as `2-3`. It limits keyword
-  matching and all normal field extraction to that part of the PDF. Use it for
-  documents with cover, envelope or terms pages that must not influence the
-  invoice match. A page-scoped template needs a reader that supports it;
-  `pdftotext` and `pdfium` do.
+- `pages`: Optional inclusive page range, such as `2-3` (or `2` for one page).
+  It limits keyword matching, normal field extraction and field `area:` crops
+  to that part of the PDF. Consequently, every `keywords:` value must occur on
+  a selected page. Use it for documents with cover, envelope or terms pages
+  that must not influence the invoice match. A page-scoped template needs a
+  reader that supports it; `pdftotext` and `pdfium` do.
 
 ## Fields & Parsers
 

--- a/src/invoice2data/api.py
+++ b/src/invoice2data/api.py
@@ -292,10 +292,13 @@ def _match_template_for_reader(
         if pages is not None:
             try:
                 scoped_text = extract_text(reader, invoicefile, pages=pages)
-            except (OSError, ValueError) as exc:
-                logger.warning(
+            except (OSError, TypeError, ValueError) as exc:
+                logger.debug(
                     "Template %s cannot use pages %r with %s: %s",
-                    template["template_name"], pages, reader.__name__, exc,
+                    template["template_name"],
+                    pages,
+                    reader.__name__,
+                    exc,
                 )
                 continue
         if template.matches_input(scoped_text):

--- a/src/invoice2data/api.py
+++ b/src/invoice2data/api.py
@@ -134,7 +134,9 @@ def extract_data(  # noqa: C901
         )
         logger.debug("END %s result =============================", reader.__name__)
 
-        template = _match_template(extracted_str, templates)
+        template, extracted_str = _match_template_for_reader(
+            extracted_str, templates, invoicefile, reader
+        )
         if template is None:
             continue
 
@@ -146,8 +148,8 @@ def extract_data(  # noqa: C901
         preferred = _preferred_module(template, used=reader) if auto else None
         if preferred is not None:
             preferred_str = _safe_to_text(preferred, invoicefile)
-            preferred_template = (
-                _match_template(preferred_str, templates) if preferred_str else None
+            preferred_template, preferred_str = _match_template_for_reader(
+                preferred_str, templates, invoicefile, preferred
             )
             if preferred_template is not None:
                 reader = preferred
@@ -278,6 +280,27 @@ def _match_template(
         if template.matches_input(extracted_str):
             return template
     return None
+
+
+def _match_template_for_reader(
+    extracted_str: str, templates: list[InvoiceTemplate], invoicefile: str, reader: Any
+) -> tuple[InvoiceTemplate | None, str]:
+    """Match templates, applying a template's optional page scope first."""
+    for template in templates:
+        scoped_text = extracted_str
+        pages = template.get("pages")
+        if pages is not None:
+            try:
+                scoped_text = extract_text(reader, invoicefile, pages=pages)
+            except (OSError, ValueError) as exc:
+                logger.warning(
+                    "Template %s cannot use pages %r with %s: %s",
+                    template["template_name"], pages, reader.__name__, exc,
+                )
+                continue
+        if template.matches_input(scoped_text):
+            return template, scoped_text
+    return None, extracted_str
 
 
 def _by_priority(templates: list[InvoiceTemplate]) -> list[InvoiceTemplate]:

--- a/src/invoice2data/extract/invoice_template.py
+++ b/src/invoice2data/extract/invoice_template.py
@@ -270,7 +270,12 @@ class InvoiceTemplate(OrderedDictType[str, Any]):
         for k, v in self["fields"].items():
             if isinstance(v, dict):
                 optimized_str_for_parser = _handle_area(
-                    self, v, input_module, invoice_file, optimized_str
+                    self,
+                    v,
+                    input_module,
+                    invoice_file,
+                    optimized_str,
+                    self.get("pages"),
                 )
 
                 if "parser" in v:
@@ -336,11 +341,14 @@ def _handle_area(
     input_module: Any,
     invoice_file: str,
     optimized_str: str,
+    pages: Any = None,
 ) -> str:
     """Handle area-specific extraction."""
     if "area" in v and supports_area(input_module):
         logger.debug(f"Area was specified with parameters {v['area']}")
-        optimized_str_area: str = extract_text(input_module, invoice_file, v["area"])
+        optimized_str_area: str = extract_text(
+            input_module, invoice_file, v["area"], pages=pages
+        )
         logger.debug(
             "START pdftotext area result ===========================\n%s",
             optimized_str_area,

--- a/src/invoice2data/input/__init__.py
+++ b/src/invoice2data/input/__init__.py
@@ -8,6 +8,7 @@ from functools import lru_cache
 from pathlib import Path
 from types import ModuleType
 from typing import Any
+from typing import TypeAlias
 
 from . import doctr
 from . import gvision
@@ -21,6 +22,10 @@ from . import pdfplumber
 from . import pdftotext
 from . import tesseract
 from . import text
+
+
+PageRange: TypeAlias = tuple[int, int]
+PageSpec: TypeAlias = int | str | PageRange
 
 
 #: Registry: backend name (the ``--input-reader`` value) -> backend module.
@@ -77,7 +82,7 @@ def _cached_to_text(
     invoicefile: str,
     mtime: float | None,
     area_key: tuple[tuple[str, Any], ...] | None,
-    pages: tuple[int, int] | None,
+    pages: PageRange | None,
 ) -> str:
     """Memoized backend call (key includes file mtime + area for correctness)."""
     # Keep the established positional ``area`` call compatible with third-party
@@ -92,9 +97,11 @@ def _cached_to_text(
     return str(module.to_text(invoicefile, **kwargs))
 
 
-def parse_pages(value: Any) -> tuple[int, int]:
+def parse_pages(value: PageSpec) -> PageRange:
     """Parse a template's inclusive ``pages`` value (for example ``"2-3"``)."""
-    if isinstance(value, int):
+    if isinstance(value, tuple) and len(value) == 2:
+        first, last = value
+    elif isinstance(value, int):
         first = last = value
     elif isinstance(value, str):
         parts = value.split("-", maxsplit=1)
@@ -102,19 +109,34 @@ def parse_pages(value: Any) -> tuple[int, int]:
             first = int(parts[0].strip())
             last = int(parts[-1].strip())
         except ValueError as exc:
-            raise ValueError("pages must be a page number or an inclusive range such as '2-3'") from exc
+            message = "pages must be a page number or an inclusive range such as '2-3'"
+            raise ValueError(message) from exc
     else:
-        raise TypeError("pages must be a page number or an inclusive range such as '2-3'")
+        raise TypeError(
+            "pages must be a page number or an inclusive range such as '2-3'"
+        )
     if first < 1 or last < first:
         raise ValueError("pages must be positive and ordered, for example '2-3'")
     return first, last
+
+
+def _scope_area_to_pages(
+    area: dict[str, Any], pages: PageRange
+) -> dict[str, Any] | None:
+    """Intersect an area's declared pages with a template page range."""
+    if "f" not in area or "l" not in area:
+        return area
+    scoped = dict(area)
+    scoped["f"] = max(int(area["f"]), pages[0])
+    scoped["l"] = min(int(area["l"]), pages[1])
+    return scoped if scoped["f"] <= scoped["l"] else None
 
 
 def extract_text(
     module: ModuleType,
     invoicefile: str,
     area: dict[str, Any] | None = None,
-    pages: Any = None,
+    pages: PageSpec | None = None,
 ) -> str:
     """Extract text with a backend, memoized per (backend, file, mtime, area).
 
@@ -126,20 +148,31 @@ def extract_text(
         module (ModuleType): An input backend exposing ``to_text``.
         invoicefile (str): Path to the document.
         area (dict[str, Any] | None): Optional area-restriction passed through.
-        pages (int | str | None): Optional inclusive page or page range, such as
+        pages (PageSpec | None): Optional inclusive page or page range, such as
             ``2`` or ``"2-3"``. The backend must support page ranges.
 
     Returns:
         str: The extracted text.
+
+    Raises:
+        TypeError: If ``pages`` has an unsupported type.
+        ValueError: If ``pages`` is malformed or the backend lacks page-range
+            support.
     """
     try:
         mtime: float | None = Path(invoicefile).stat().st_mtime
     except OSError:
         mtime = None
-    area_key = tuple(sorted(area.items())) if area else None
     page_range = parse_pages(pages) if pages is not None else None
     if page_range is not None and not supports_pages(module):
-        raise ValueError(f"Input backend {module.__name__} does not support page ranges")
+        raise ValueError(
+            f"Input backend {module.__name__} does not support page ranges"
+        )
+    if area is not None and page_range is not None:
+        area = _scope_area_to_pages(area, page_range)
+        if area is None:
+            return ""
+    area_key = tuple(sorted(area.items())) if area else None
     return _cached_to_text(module, invoicefile, mtime, area_key, page_range)
 
 

--- a/src/invoice2data/input/__init__.py
+++ b/src/invoice2data/input/__init__.py
@@ -52,6 +52,11 @@ def supports_area(module: ModuleType) -> bool:
     return bool(getattr(module, "SUPPORTS_AREA", False))
 
 
+def supports_pages(module: ModuleType) -> bool:
+    """Return whether a backend can restrict extraction to a page range."""
+    return bool(getattr(module, "SUPPORTS_PAGES", False))
+
+
 def is_available(module: ModuleType) -> bool:
     """Return whether a backend's runtime dependency is available.
 
@@ -72,15 +77,44 @@ def _cached_to_text(
     invoicefile: str,
     mtime: float | None,
     area_key: tuple[tuple[str, Any], ...] | None,
+    pages: tuple[int, int] | None,
 ) -> str:
     """Memoized backend call (key includes file mtime + area for correctness)."""
-    if area_key is None:
-        return str(module.to_text(invoicefile))
-    return str(module.to_text(invoicefile, dict(area_key)))
+    # Keep the established positional ``area`` call compatible with third-party
+    # readers. Page-aware readers receive the additional keyword explicitly.
+    if pages is None:
+        if area_key is None:
+            return str(module.to_text(invoicefile))
+        return str(module.to_text(invoicefile, dict(area_key)))
+    kwargs: dict[str, Any] = {"pages": pages}
+    if area_key is not None:
+        kwargs["area_details"] = dict(area_key)
+    return str(module.to_text(invoicefile, **kwargs))
+
+
+def parse_pages(value: Any) -> tuple[int, int]:
+    """Parse a template's inclusive ``pages`` value (for example ``"2-3"``)."""
+    if isinstance(value, int):
+        first = last = value
+    elif isinstance(value, str):
+        parts = value.split("-", maxsplit=1)
+        try:
+            first = int(parts[0].strip())
+            last = int(parts[-1].strip())
+        except ValueError as exc:
+            raise ValueError("pages must be a page number or an inclusive range such as '2-3'") from exc
+    else:
+        raise TypeError("pages must be a page number or an inclusive range such as '2-3'")
+    if first < 1 or last < first:
+        raise ValueError("pages must be positive and ordered, for example '2-3'")
+    return first, last
 
 
 def extract_text(
-    module: ModuleType, invoicefile: str, area: dict[str, Any] | None = None
+    module: ModuleType,
+    invoicefile: str,
+    area: dict[str, Any] | None = None,
+    pages: Any = None,
 ) -> str:
     """Extract text with a backend, memoized per (backend, file, mtime, area).
 
@@ -92,6 +126,8 @@ def extract_text(
         module (ModuleType): An input backend exposing ``to_text``.
         invoicefile (str): Path to the document.
         area (dict[str, Any] | None): Optional area-restriction passed through.
+        pages (int | str | None): Optional inclusive page or page range, such as
+            ``2`` or ``"2-3"``. The backend must support page ranges.
 
     Returns:
         str: The extracted text.
@@ -101,7 +137,10 @@ def extract_text(
     except OSError:
         mtime = None
     area_key = tuple(sorted(area.items())) if area else None
-    return _cached_to_text(module, invoicefile, mtime, area_key)
+    page_range = parse_pages(pages) if pages is not None else None
+    if page_range is not None and not supports_pages(module):
+        raise ValueError(f"Input backend {module.__name__} does not support page ranges")
+    return _cached_to_text(module, invoicefile, mtime, area_key, page_range)
 
 
 def available_modules() -> dict[str, ModuleType]:

--- a/src/invoice2data/input/__interface__.py
+++ b/src/invoice2data/input/__interface__.py
@@ -13,6 +13,11 @@ False):
 
     SUPPORTS_AREA = True
 
+Likewise, a backend may support a template-wide inclusive page range supplied
+as ``pages=(first, last)``. It declares that capability explicitly:
+
+    SUPPORTS_PAGES = True
+
 A backend may declare an availability check, used so it self-excludes when a
 runtime dependency (a Python package or a system binary) is missing:
 

--- a/src/invoice2data/input/pdfium.py
+++ b/src/invoice2data/input/pdfium.py
@@ -18,6 +18,7 @@ logger = getLogger(__name__)
 
 #: PDFium can extract a bounded region in-process (see _crop_pages).
 SUPPORTS_AREA = True
+SUPPORTS_PAGES = True
 
 
 def is_available() -> bool:
@@ -32,7 +33,10 @@ def is_available() -> bool:
 
 
 def to_text(
-    path: str, area_details: dict[str, Any] | None = None, **kwargs: Any
+    path: str,
+    area_details: dict[str, Any] | None = None,
+    pages: tuple[int, int] | None = None,
+    **kwargs: Any,
 ) -> str:
     """Extract text from a PDF using pypdfium2.
 
@@ -42,6 +46,7 @@ def to_text(
             Keys (pixels at ``r`` dpi, top-left origin): ``f``/``l`` (first/last
             page), ``x``/``y`` (top-left), ``W``/``H`` (size), ``r`` (dpi).
             Defaults to None (whole document).
+        pages (tuple[int, int] | None): Optional inclusive page range.
         **kwargs (Any): Ignored; accepted for backend compatibility.
 
     Returns:
@@ -52,16 +57,17 @@ def to_text(
     document = pypdfium2.PdfDocument(path)
     try:
         if area_details is not None:
-            pages = _crop_pages(document, area_details)
+            extracted_pages = _crop_pages(document, area_details)
         else:
-            pages = [
+            first, last = pages or (1, len(document))
+            extracted_pages = [
                 document[index].get_textpage().get_text_bounded()
-                for index in range(len(document))
+                for index in range(first - 1, min(last, len(document)))
             ]
     finally:
         document.close()
     logger.debug("Text extraction made with pypdfium2")
-    return _post_process("\n".join(pages))
+    return _post_process("\n".join(extracted_pages))
 
 
 def _crop_pages(document: Any, area: dict[str, Any]) -> list[str]:

--- a/src/invoice2data/input/pdftotext.py
+++ b/src/invoice2data/input/pdftotext.py
@@ -17,6 +17,7 @@ from ..exceptions import TemplateSyntaxError
 
 
 SUPPORTS_AREA = True
+SUPPORTS_PAGES = True
 
 #: A parsed word: ``(page, xMin, yMin, xMax, yMax, text)`` with coords in points.
 _Word = tuple[int, float, float, float, float, str]
@@ -144,7 +145,11 @@ def _crop(words: tuple[_Word, ...], area: dict[str, Any]) -> str:
     )
 
 
-def to_text(path: str, area_details: dict[str, Any] | None = None) -> str:
+def to_text(
+    path: str,
+    area_details: dict[str, Any] | None = None,
+    pages: tuple[int, int] | None = None,
+) -> str:
     """Extract text from a PDF file using pdftotext.
 
     Args:
@@ -153,6 +158,7 @@ def to_text(path: str, area_details: dict[str, Any] | None = None) -> str:
             region. Keys (pixels at ``r`` dpi): ``f``/``l`` (first/last page),
             ``x``/``y`` (top-left), ``W``/``H`` (size), ``r`` (resolution dpi).
             Defaults to None (whole document).
+        pages (tuple[int, int] | None): Optional inclusive page range.
 
     Returns:
         str: The extracted text.
@@ -182,6 +188,9 @@ def to_text(path: str, area_details: dict[str, Any] | None = None) -> str:
 
     import subprocess
 
-    cmd = ["pdftotext", "-layout", "-q", "-enc", "UTF-8", path, "-"]
+    cmd = ["pdftotext", "-layout", "-q", "-enc", "UTF-8"]
+    if pages is not None:
+        cmd.extend(["-f", str(pages[0]), "-l", str(pages[1])])
+    cmd.extend([path, "-"])
     out, _ = subprocess.Popen(cmd, stdout=subprocess.PIPE).communicate()
     return out.decode("utf-8")

--- a/tests/test_page_ranges.py
+++ b/tests/test_page_ranges.py
@@ -1,7 +1,9 @@
 """Template-wide page ranges apply before keyword matching and extraction."""
 
 import types
+from logging import DEBUG
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -13,8 +15,14 @@ def _page_reader() -> types.ModuleType:
     """Return a backend whose text makes its selected range observable."""
     module = types.ModuleType("page_reader")
     module.SUPPORTS_PAGES = True  # type: ignore[attr-defined]
+    module.SUPPORTS_AREA = True  # type: ignore[attr-defined]
 
-    def to_text(_path: str, _area=None, pages=None) -> str:
+    def to_text(
+        _path: str,
+        area_details: dict[str, Any] | None = None,
+        pages: tuple[int, int] | None = None,
+    ) -> str:
+        _ = area_details
         return f"page {pages[0]}-{pages[1]}" if pages else "all pages"
 
     module.to_text = to_text  # type: ignore[attr-defined]
@@ -42,16 +50,96 @@ def test_scoped_template_matches_only_its_selected_pages(tmp_path: Path) -> None
     assert selected_text == "page 2-3"
 
 
-@pytest.mark.parametrize("value, expected", [(2, (2, 2)), ("2", (2, 2)), ("2-3", (2, 3))])
-def test_page_syntax_is_accepted(value, expected) -> None:
+@pytest.mark.parametrize(
+    "value, expected", [(2, (2, 2)), ("2", (2, 2)), ("2-3", (2, 3))]
+)
+def test_page_syntax_is_accepted(value: Any, expected: tuple[int, int]) -> None:
     from invoice2data.input import parse_pages
 
     assert parse_pages(value) == expected
 
 
-@pytest.mark.parametrize("value", ["0", "3-2", "two", [2, 3]])
-def test_invalid_page_syntax_is_rejected(value) -> None:
+@pytest.mark.parametrize("value", ["0", "2-", "3-2", "two", [2, 3]])
+def test_invalid_page_syntax_is_rejected(value: Any) -> None:
     from invoice2data.input import parse_pages
 
     with pytest.raises((TypeError, ValueError), match="pages must"):
         parse_pages(value)
+
+
+def test_area_is_limited_to_the_template_page_range(tmp_path: Path) -> None:
+    """A field area cannot escape a template-wide page restriction."""
+    from invoice2data.input import extract_text
+
+    pdf = tmp_path / "document.pdf"
+    pdf.write_bytes(b"%PDF-1.4")
+    calls: list[tuple[dict[str, Any] | None, tuple[int, int] | None]] = []
+    reader = _page_reader()
+
+    def to_text(
+        _path: str,
+        area_details: dict[str, Any] | None = None,
+        pages: tuple[int, int] | None = None,
+    ) -> str:
+        calls.append((area_details, pages))
+        return "area"
+
+    reader.to_text = to_text  # type: ignore[attr-defined]
+    assert extract_text(reader, str(pdf), {"f": 1, "l": 3}, pages="2-3") == "area"
+    assert calls == [({"f": 2, "l": 3}, (2, 3))]
+    assert extract_text(reader, str(pdf), {"f": 1, "l": 1}, pages="2-3") == ""
+
+
+def test_template_area_receives_the_template_page_range(tmp_path: Path) -> None:
+    """The template passes its page scope through to a field area."""
+    from invoice2data.extract.invoice_template import _handle_area
+
+    pdf = tmp_path / "document.pdf"
+    pdf.write_bytes(b"%PDF-1.4")
+    reader = _page_reader()
+    template = InvoiceTemplate(
+        {
+            "template_name": "page-two.yml",
+            "keywords": ["page 2-3"],
+            "exclude_keywords": [],
+            "pages": "2-3",
+        }
+    )
+
+    assert (
+        _handle_area(
+            template,
+            {"area": {"f": 1, "l": 3}},
+            reader,
+            str(pdf),
+            "all pages",
+            template["pages"],
+        )
+        == "page 2-3"
+    )
+
+
+def test_page_scoped_template_skips_unsupported_reader(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Cascade matching skips, rather than warns for, an unsuitable reader."""
+    pdf = tmp_path / "document.pdf"
+    pdf.write_bytes(b"%PDF-1.4")
+    reader = _page_reader()
+    reader.SUPPORTS_PAGES = False  # type: ignore[attr-defined]
+    template = InvoiceTemplate(
+        {
+            "template_name": "page-two.yml",
+            "keywords": ["page 2-3"],
+            "exclude_keywords": [],
+            "pages": "2-3",
+        }
+    )
+    caplog.set_level(DEBUG)
+
+    selected, _text = _match_template_for_reader(
+        "all pages", [template], str(pdf), reader
+    )
+
+    assert selected is None
+    assert "cannot use pages" in caplog.text

--- a/tests/test_page_ranges.py
+++ b/tests/test_page_ranges.py
@@ -1,0 +1,57 @@
+"""Template-wide page ranges apply before keyword matching and extraction."""
+
+import types
+from pathlib import Path
+
+import pytest
+
+from invoice2data.api import _match_template_for_reader
+from invoice2data.extract.invoice_template import InvoiceTemplate
+
+
+def _page_reader() -> types.ModuleType:
+    """Return a backend whose text makes its selected range observable."""
+    module = types.ModuleType("page_reader")
+    module.SUPPORTS_PAGES = True  # type: ignore[attr-defined]
+
+    def to_text(_path: str, _area=None, pages=None) -> str:
+        return f"page {pages[0]}-{pages[1]}" if pages else "all pages"
+
+    module.to_text = to_text  # type: ignore[attr-defined]
+    return module
+
+
+def test_scoped_template_matches_only_its_selected_pages(tmp_path: Path) -> None:
+    """Page scoping is applied before a template's keywords are evaluated."""
+    pdf = tmp_path / "document.pdf"
+    pdf.write_bytes(b"%PDF-1.4")
+    template = InvoiceTemplate(
+        {
+            "template_name": "page-two.yml",
+            "keywords": ["page 2-3"],
+            "exclude_keywords": [],
+            "pages": "2-3",
+        }
+    )
+
+    selected, selected_text = _match_template_for_reader(
+        "all pages", [template], str(pdf), _page_reader()
+    )
+
+    assert selected is template
+    assert selected_text == "page 2-3"
+
+
+@pytest.mark.parametrize("value, expected", [(2, (2, 2)), ("2", (2, 2)), ("2-3", (2, 3))])
+def test_page_syntax_is_accepted(value, expected) -> None:
+    from invoice2data.input import parse_pages
+
+    assert parse_pages(value) == expected
+
+
+@pytest.mark.parametrize("value", ["0", "3-2", "two", [2, 3]])
+def test_invalid_page_syntax_is_rejected(value) -> None:
+    from invoice2data.input import parse_pages
+
+    with pytest.raises((TypeError, ValueError), match="pages must"):
+        parse_pages(value)


### PR DESCRIPTION
 ## Summary

  Adds an optional top-level template setting:

  ```yaml
  pages: "2-3"

  It restricts template matching and extraction to an inclusive page range.
  pdftotext and PDFium explicitly support it; unsupported readers are skipped
  for such a template.

  ## Tests

  19 targeted tests passed, including page-range syntax, scoped matching, text
  caching and area extraction.
