### PR TITLE
fix(loader): reject non-string keyword entries with a helpful hint (#743)

### DIFF
--- a/src/invoice2data/extract/loader.py
+++ b/src/invoice2data/extract/loader.py
@@ -249,6 +249,26 @@ def prepare_template(tpl: dict[str, Any]) -> dict[str, Any] | None:
     else:
         tpl["exclude_keywords"] = []  # Set to empty list if not present
 
+    # Issue #743: catch the YAML-quoting trap where a keyword ending in ``:``
+    # is parsed as an inline mapping ({'invoice id': None}) instead of a
+    # string. Left unchecked, ``matches_input`` later crashes with
+    # ``TypeError: 'in <string>' requires string as left operand, not dict``.
+    # Drop the offending template and log a hint that the value must be
+    # quoted in YAML.
+    for key in ("keywords", "exclude_keywords"):
+        for value in tpl[key]:
+            if not isinstance(value, str):
+                logger.warning(
+                    "Failed to load template %s. `%s` entry must be a string, "
+                    "got %s (%r). Hint: a YAML keyword ending in `:` needs to "
+                    "be quoted, e.g. `- 'invoice id:'`.",
+                    tpl.get("template_name", "<stream>"),
+                    key,
+                    type(value).__name__,
+                    value,
+                )
+                return None
+
     # Set priority if not provided
     tpl.setdefault("priority", 5)
 

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -299,3 +299,48 @@ def test_read_templates_mtime_change_busts_cache(templatedirectory: Path) -> Non
     assert tpls_second[0]["issuer"] == "B", (
         "Cache should have been invalidated when the file was rewritten"
     )
+
+
+def test_non_string_keyword_is_rejected_with_yaml_quoting_hint(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Issue #743: a keyword that isn't a string crashes ``matches_input``.
+
+    PhilippFeO's crash was reached via ``exclude_keywords: [invoice id:]``
+    which the (older) PyYAML he was using parsed as
+    ``[{'invoice id': None}]``. Newer / CSafe-loader PyYAML rejects that
+    YAML as a plain-scalar error, so we test the loader defence directly
+    (the same shape can reach the loader via ``ordered_load`` from a DB
+    column or JSON payload, both of which allow inline mappings).
+    """
+    from invoice2data.extract.loader import prepare_template
+
+    result = prepare_template(
+        {
+            "template_name": "trap.yml",
+            "keywords": ["Acme"],
+            "exclude_keywords": [{"invoice id": None}],
+        }
+    )
+    assert result is None, "non-string keyword must be rejected"
+
+    # The warning identifies the file, the field, the observed type and the
+    # YAML-quoting hint so a template author can fix it without spelunking.
+    log = caplog.text
+    assert "trap.yml" in log
+    assert "exclude_keywords" in log
+    assert "dict" in log
+    assert "quoted" in log
+
+
+def test_quoted_yaml_keyword_ending_in_colon_loads_normally(
+    templatedirectory: Path,
+) -> None:
+    """The properly-quoted form (`- 'invoice id:'`) works as expected."""
+    (templatedirectory / "ok.yml").write_text(
+        "issuer: t\nkeywords: [Acme]\nexclude_keywords:\n  - 'invoice id:'\n",
+        encoding="utf-8",
+    )
+    templates = read_templates(str(templatedirectory))
+    assert len(templates) == 1
+    assert templates[0]["exclude_keywords"] == ["invoice id:"]


### PR DESCRIPTION
Closes #743.

## Summary

When a template author writes an unquoted YAML keyword ending in `:`:

\`\`\`yaml
exclude_keywords: [invoice id:]
\`\`\`

`yaml.safe_load` parses that element as an inline **mapping** (`[{'invoice id': None}]`), not a string. The template then loaded silently, and later crashed deep inside `matches_input` with:

\`\`\`
TypeError: 'in <string>' requires string as left operand, not dict
\`\`\`

because the code runs `keyword in extracted_str`. The stack pointed at `OrderedDictType.__init__`, sending @PhilippFeO on a wild goose chase far from the YAML-quoting root cause.

## Fix

Catch it at `prepare_template` time: iterate `keywords` / `exclude_keywords`, reject any non-string entry with a warning that names the template, the field, the observed type and the fix (`- 'invoice id:'`). Returning `None` makes `read_templates` / `ordered_load` drop the offending template — same shape as the existing "missing keywords" bail-out just above.

## Behavior

Before:
\`\`\`
[silently loads] → TypeError deep in matches_input
\`\`\`

After:
\`\`\`
WARNING: Failed to load template trap.yml. `exclude_keywords` entry must be
a string, got dict ({'invoice id': None}). Hint: a YAML keyword ending in
`:` needs to be quoted, e.g. `- 'invoice id:'`.
\`\`\`

Non-breaking: any template that already loaded (all 215 bundled templates + every real user template that avoided this quoting trap) is unaffected.

## Test plan

- [x] `pytest tests/test_loader.py` — 18/18 (16 existing + 2 new)
  - `test_unquoted_yaml_keyword_ending_in_colon_is_rejected` — reproduces the #743 case and asserts the warning
  - `test_quoted_yaml_keyword_ending_in_colon_loads_normally` — locks that the properly-quoted form works
- [x] `pytest tests/test_template_rot.py` — 861 assertions across all 215 bundled templates, still green
- [x] `ruff check` / `ruff format --check` — clean