### PR TITLE
fix(#742): match keywords as regex, matching the documented tutorial

### DIFF
--- a/src/invoice2data/extract/_regex.py
+++ b/src/invoice2data/extract/_regex.py
@@ -26,6 +26,11 @@ if os.environ.get("INVOICE2DATA_REGEX_ENGINE", "re").lower() == "regex":
 #: Name of the active regex engine ("re" or "regex").
 ENGINE: str = _engine.__name__
 
+#: The active engine's ``PatternError``/``error`` type, re-exported so callers
+#: can ``except _regex.error`` without caring which engine is active. Both
+#: engines expose the same attribute name.
+error = _engine.error
+
 
 @lru_cache(maxsize=4096)
 def compile(pattern: str, flags: int = 0) -> "re.Pattern[str]":

--- a/src/invoice2data/extract/invoice_template.py
+++ b/src/invoice2data/extract/invoice_template.py
@@ -32,10 +32,10 @@ optimized_str_logger = getLogger("invoice2data.optimized_str")
 
 
 def _keyword_matches(keyword: str, text: str) -> bool:
-    """Return whether ``keyword`` matches ``text`` as a regex (issue #742).
+    r"""Return whether ``keyword`` matches ``text`` as a regex (issue #742).
 
     The tutorial has always documented ``keywords`` / ``exclude_keywords`` as
-    regex patterns (e.g. ``Company\\s+(US|UK)``, ``(?i)Accor``), but the code
+    regex patterns (e.g. ``Company\s+(US|UK)``, ``(?i)Accor``), but the code
     was doing a plain ``in`` substring test -- so ~16 bundled templates that
     already used regex syntax silently under-matched. Use :func:`regex.search`
     to honour the documented contract.

--- a/src/invoice2data/extract/invoice_template.py
+++ b/src/invoice2data/extract/invoice_template.py
@@ -31,6 +31,32 @@ logger = getLogger(__name__)
 optimized_str_logger = getLogger("invoice2data.optimized_str")
 
 
+def _keyword_matches(keyword: str, text: str) -> bool:
+    """Return whether ``keyword`` matches ``text`` as a regex (issue #742).
+
+    The tutorial has always documented ``keywords`` / ``exclude_keywords`` as
+    regex patterns (e.g. ``Company\\s+(US|UK)``, ``(?i)Accor``), but the code
+    was doing a plain ``in`` substring test -- so ~16 bundled templates that
+    already used regex syntax silently under-matched. Use :func:`regex.search`
+    to honour the documented contract.
+
+    Falls back to a plain substring check when the pattern does not compile
+    as valid regex, so an existing simple-string keyword containing a stray
+    metacharacter (``Company (Ltd)``) keeps matching literally instead of
+    breaking. The fallback is DEBUG-logged so a template author can spot it
+    when investigating why their pattern didn't match.
+    """
+    try:
+        return _regex.search(keyword, text) is not None
+    except _regex.error as exc:
+        logger.debug(
+            "keyword %r is not a valid regex (%s); falling back to substring match",
+            keyword,
+            exc,
+        )
+        return keyword in text
+
+
 OPTIONS_DEFAULT = {
     "remove_whitespace": False,
     "remove_accents": False,
@@ -131,6 +157,13 @@ class InvoiceTemplate(OrderedDictType[str, Any]):
     def matches_input(self, extracted_str: str) -> bool:
         """Check if the extracted string matches the template keywords.
 
+        ``keywords`` and ``exclude_keywords`` are matched as **regex patterns**
+        (the documented long-standing contract in the tutorial). A keyword is
+        considered found when :func:`regex.search` returns a match anywhere in
+        the extracted text. Any keyword that does not compile as a valid regex
+        falls back to a plain substring check, so simple string keywords like
+        ``"ACME"`` continue to work unchanged.
+
         Args:
             extracted_str (str): The extracted text from the invoice.
 
@@ -138,11 +171,10 @@ class InvoiceTemplate(OrderedDictType[str, Any]):
             bool: True if the extracted string matches the template keywords,
                 False otherwise.
         """
-        if all(keyword in extracted_str for keyword in self["keywords"]):
+        if all(_keyword_matches(k, extracted_str) for k in self["keywords"]):
             # All keywords found
             if self["exclude_keywords"] and any(
-                exclude_keyword in extracted_str
-                for exclude_keyword in self["exclude_keywords"]
+                _keyword_matches(k, extracted_str) for k in self["exclude_keywords"]
             ):
                 # At least one exclude_keyword found
                 logger.debug(

--- a/tests/test_invoice_template.py
+++ b/tests/test_invoice_template.py
@@ -207,5 +207,57 @@ def test_missing_currency_falls_back_to_option() -> None:
     assert extracted["currency"] == "EUR"
 
 
+def _keyword_template(keywords: list[str], excludes: list[str] | None = None) -> InvoiceTemplate:
+    """Build a minimal template with the given keywords / exclude_keywords."""
+    return InvoiceTemplate(
+        {
+            "template_name": "kw.yml",
+            "keywords": keywords,
+            "exclude_keywords": excludes or [],
+        }
+    )
+
+
+class TestMatchesInputRegex:
+    """Issue #742: keywords / exclude_keywords are regex, not plain substrings."""
+
+    def test_plain_string_keyword_still_matches(self) -> None:
+        assert _keyword_template(["Acme Corp"]).matches_input("Hello Acme Corp inv#1")
+
+    def test_regex_whitespace_metachar_matches_multiple_spaces(self) -> None:
+        """`Company\\s+US` should match `Company    US` (multi-space)."""
+        assert _keyword_template([r"Company\s+US"]).matches_input(
+            "Invoice from Company    US"
+        )
+
+    def test_regex_alternation_matches_either_branch(self) -> None:
+        """`Company\\s+(US|UK)` should match either branch."""
+        tpl = _keyword_template([r"Company\s+(US|UK)"])
+        assert tpl.matches_input("Company US invoice")
+        assert tpl.matches_input("Company UK invoice")
+        assert not tpl.matches_input("Company CA invoice")
+
+    def test_case_insensitive_flag_prefix_matches(self) -> None:
+        """`(?i)Accor` should match `accor`, `ACCOR`, `Accor`."""
+        tpl = _keyword_template(["(?i)Accor"])
+        assert tpl.matches_input("hotel accor invoice")
+        assert tpl.matches_input("HOTEL ACCOR invoice")
+
+    def test_exclude_keyword_is_also_regex(self) -> None:
+        """`exclude_keywords: (?i)draft` blocks the template on `DRAFT`/`draft`."""
+        tpl = _keyword_template(["Acme"], ["(?i)draft"])
+        assert not tpl.matches_input("Acme DRAFT invoice")
+        assert tpl.matches_input("Acme final invoice")
+
+    def test_invalid_regex_falls_back_to_substring(self) -> None:
+        """A stray `[` isn't valid regex but should still match literally."""
+        # `Company [Ltd]` is invalid regex (unclosed character class after group),
+        # but plenty of legacy templates might include unescaped brackets/parens.
+        # Fallback: literal substring.
+        tpl = _keyword_template(["Company [Ltd"])
+        assert tpl.matches_input("Payment to Company [Ltd for services")
+        assert not tpl.matches_input("Payment to Company Ltd for services")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_invoice_template.py
+++ b/tests/test_invoice_template.py
@@ -207,7 +207,9 @@ def test_missing_currency_falls_back_to_option() -> None:
     assert extracted["currency"] == "EUR"
 
 
-def _keyword_template(keywords: list[str], excludes: list[str] | None = None) -> InvoiceTemplate:
+def _keyword_template(
+    keywords: list[str], excludes: list[str] | None = None
+) -> InvoiceTemplate:
     """Build a minimal template with the given keywords / exclude_keywords."""
     return InvoiceTemplate(
         {
@@ -225,13 +227,13 @@ class TestMatchesInputRegex:
         assert _keyword_template(["Acme Corp"]).matches_input("Hello Acme Corp inv#1")
 
     def test_regex_whitespace_metachar_matches_multiple_spaces(self) -> None:
-        """`Company\\s+US` should match `Company    US` (multi-space)."""
+        r"""`Company\s+US` should match `Company    US` (multi-space)."""
         assert _keyword_template([r"Company\s+US"]).matches_input(
             "Invoice from Company    US"
         )
 
     def test_regex_alternation_matches_either_branch(self) -> None:
-        """`Company\\s+(US|UK)` should match either branch."""
+        r"""`Company\s+(US|UK)` should match either branch."""
         tpl = _keyword_template([r"Company\s+(US|UK)"])
         assert tpl.matches_input("Company US invoice")
         assert tpl.matches_input("Company UK invoice")


### PR DESCRIPTION
## Summary

Closes #742.

The template-authoring tutorial has always documented `keywords` and `exclude_keywords` as **regex patterns**  e.g. \"`Company US` and `Company\s+US` both work\". But `InvoiceTemplate.matches_input` used a plain `in` substring test, so any keyword that leaned on a regex metachar silently under-matched.

An audit of the bundled templates shows ~16 already write regex-shaped keywords that were effectively broken:

- `(?i)Accor`, `(?i)Digital\sRiver`
- `BE\s0673\s923`
- `Express\s+\w+`
- `Wystawił\(a\)`
- `NL8152[.]54[.]295[.]B01`
- …and more.

## Change

- Route both `keywords` and `exclude_keywords` checks through a new module-local `_keyword_matches` helper that calls `_regex.search` (the compile-once cache used everywhere else in `extract/`).
- If a keyword doesn't compile as valid regex, fall back to a literal substring check and DEBUG-log the fallback  so a stray unescaped `[` or `(` in a simple-string keyword like `Company [Ltd` keeps matching literally instead of breaking.
- Re-export `_regex.error` (the active engine's error type  `re.error` by default, `regex.error` under `INVOICE2DATA_REGEX_ENGINE=regex`) so the fallback doesn't need to know which engine is active.

## Compatibility

- Plain-string keywords with no metacharacters (`Acme Corp`) behave exactly as before — `regex.search(\"Acme Corp\", text)` is the same as `\"Acme Corp\" in text`.
- Keywords that already were regex (bundled templates) now actually work.
- Keywords that were **string-but-look-like-regex** (rare  `Company [Ltd` with an unclosed `[`) still match via the literal fallback.

## Test plan

- [x] New unit tests for regex `\s+`, `(?i)`, alternation, exclude-as-regex, and invalid-regex-falls-back-to-substring.
- [x] Existing test suite passes (only the pre-existing env-related failures remain — `test_gvision`, `test_copy` needing pdftotext/tesseract, and `QualityHosting.pdf` cascade, all red on master too).
- [x] `test_default_templates_are_loaded` still loads every bundled template (nothing rejected as invalid regex).
