### PR TITLE
feat(parsers/lines): add `alternatives:` for first-non-empty-wins layout fallback (#759)

### DIFF
--- a/docs/recommended-template-fields.md
+++ b/docs/recommended-template-fields.md
@@ -134,6 +134,38 @@ lines:
 
 A single pattern can be given as a string; multiple as a list.
 
+### Layout alternatives (`alternatives:`)
+
+Some vendors mail out invoices in two structurally different layouts (an old
+one and a new one, an itemised version and a summary version, etc.). Instead
+of maintaining two full templates or stuffing two `lines` blocks into one
+mapping (which YAML would collapse), list each candidate layout under
+`alternatives:`. Each entry is a full lines-block; the parser tries them in
+order and returns the rows of the **first** entry that yields any rows.
+Later alternatives are not consulted once one succeeds.
+
+```yaml
+fields:
+  lines:
+    parser: lines
+    alternatives:
+      - start: BEGIN NEW LAYOUT
+        end: END
+        line: (?P<code>C\d+)\s+(?P<qty>\d+)\s+(?P<price_unit>\d+\.\d+)
+      - start: Order                       # legacy layout, fires only if
+        end: Total                         # the new one matched nothing
+        line: (?P<sku>SKU\d+)\s+(?P<qty>\d+)\s+(?P<price_unit>\d+\.\d+)
+```
+
+Keys set outside `alternatives:` (e.g. `line_separator`, `types`, `replace`)
+apply to whichever alternative wins; a per-alternative key overrides the
+shared one.
+
+`alternatives:` differs from `rules:` — `rules:` runs every entry and
+**concatenates** the results (good for two structurally different regions of
+the same invoice); `alternatives:` picks the first non-empty one (good for
+"one of these layouts, not both"). An alternative may itself use `rules:`.
+
 ### Extracting numbers from text (`extract_number`)
 
 For regex fields whose capture contains units or currency mixed with the

--- a/src/invoice2data/extract/parsers/lines.py
+++ b/src/invoice2data/extract/parsers/lines.py
@@ -317,6 +317,20 @@ def parse(
 ) -> list[dict[str, Any]]:
     """Parse lines from the content based on the given settings.
 
+    Supports three shapes:
+
+    - Single mapping (original syntax): one block, one line pattern.
+    - ``rules:`` list: multiple blocks, results are **concatenated**.
+    - ``alternatives:`` list: multiple blocks, **first non-empty wins**
+      (issue #759). Each alternative is a full settings mapping; keys at
+      the top level (outside ``alternatives``) merge in as shared defaults
+      that a specific alternative can override.
+
+    ``alternatives`` and ``rules`` may be nested (an alternative can
+    itself use ``rules`` to concatenate several sub-blocks), but at a
+    single level they are mutually exclusive; if both appear together
+    ``alternatives`` wins and a warning is logged.
+
     Args:
         template (InvoiceTemplate): The template dictionary.
         field (str): The field name.
@@ -326,6 +340,45 @@ def parse(
     Returns:
         list[dict[str, Any]]: The parsed lines.
     """
+    if "alternatives" in settings:
+        if "rules" in settings:
+            logger.warning(
+                "Template %s: field '%s' has both 'alternatives' and 'rules'; "
+                "'alternatives' takes precedence and 'rules' is ignored at "
+                "this level (a single alternative may still use 'rules' "
+                "internally).",
+                template.get("template_name"),
+                field,
+            )
+        common = {
+            k: v
+            for k, v in settings.items()
+            if k not in {"parser", "alternatives", "rules"}
+        }
+        for i, alt in enumerate(settings["alternatives"]):
+            logger.debug("Testing alternative #%s for field '%s'", i, field)
+            merged = {**common, **alt}
+            rows = _parse_single(template, field, merged, content)
+            if rows:
+                logger.debug(
+                    "Alternative #%s matched %d row(s) for '%s'; stopping.",
+                    i,
+                    len(rows),
+                    field,
+                )
+                return rows
+        logger.debug("No alternative matched for field '%s'", field)
+        return []
+    return _parse_single(template, field, settings, content)
+
+
+def _parse_single(
+    template: "InvoiceTemplate",
+    field: str,
+    settings: dict[str, Any],
+    content: str,
+) -> list[dict[str, Any]]:
+    """Dispatch one settings mapping through the rules/single-block logic."""
     if "rules" in settings:
         # One field can have multiple sets of line-parsing rules
         common = {

--- a/tests/test_lines_alternatives.py
+++ b/tests/test_lines_alternatives.py
@@ -1,0 +1,153 @@
+"""`alternatives:` on the lines parser (#759).
+
+The lines parser already had ``rules:`` for **concatenating** results from
+multiple line-parsing sub-blocks (all rules run, results appended). This
+adds a parallel ``alternatives:`` key with **first-non-empty-wins**
+semantics, so template authors can express "try layout A; if A yields
+nothing, fall back to layout B" instead of stuffing two blocks into one
+mapping and losing the first to YAML key-collision.
+"""
+
+import logging
+
+from invoice2data.extract.invoice_template import InvoiceTemplate
+from invoice2data.extract.parsers import lines as lines_parser
+
+
+_TPL = InvoiceTemplate(
+    [
+        ("issuer", "test"),
+        ("keywords", ["test"]),
+        ("exclude_keywords", []),
+        ("template_name", "alternatives.yml"),
+        (
+            "options",
+            {
+                "currency": "EUR",
+                "languages": [],
+                "decimal_separator": ".",
+                "remove_whitespace": False,
+                "remove_accents": False,
+                "lowercase": False,
+                "date_formats": [],
+                "replace": [],
+            },
+        ),
+    ]
+)
+
+
+_ALT_A = {
+    "start": r"BEGIN A",
+    "end": r"END A",
+    "line": r"^(?P<sku>SKU\d+)\s+(?P<qty>\d+)$",
+}
+_ALT_B = {
+    "start": r"BEGIN B",
+    "end": r"END B",
+    "line": r"^(?P<code>C\d+)\s+(?P<count>\d+)$",
+}
+
+
+_CONTENT_A_ONLY = "\n".join(["BEGIN A", "SKU42 3", "SKU7 1", "END A"])
+_CONTENT_B_ONLY = "\n".join(["BEGIN B", "C99 5", "END B"])
+_CONTENT_A_AND_B = "\n".join(["BEGIN A", "SKU1 1", "END A", "BEGIN B", "C2 2", "END B"])
+_CONTENT_NEITHER = "no relevant markers here at all"
+
+
+def test_first_alternative_matches_wins() -> None:
+    """When both alternatives could match, the first that yields rows wins.
+
+    B is never consulted; results are exactly A's.
+    """
+    settings = {"line_separator": r"\n", "alternatives": [_ALT_A, _ALT_B]}
+    rows = lines_parser.parse(_TPL, "lines", settings, _CONTENT_A_AND_B)
+    assert rows == [{"sku": "SKU1", "qty": "1"}]
+
+
+def test_first_alternative_empty_falls_back_to_second() -> None:
+    """A's markers absent -> A yields nothing -> B runs and returns its rows."""
+    settings = {"line_separator": r"\n", "alternatives": [_ALT_A, _ALT_B]}
+    rows = lines_parser.parse(_TPL, "lines", settings, _CONTENT_B_ONLY)
+    assert rows == [{"code": "C99", "count": "5"}]
+
+
+def test_all_alternatives_empty_returns_empty_list() -> None:
+    """No alternative matches -> empty list, not an error."""
+    settings = {"line_separator": r"\n", "alternatives": [_ALT_A, _ALT_B]}
+    rows = lines_parser.parse(_TPL, "lines", settings, _CONTENT_NEITHER)
+    assert rows == []
+
+
+def test_shared_top_level_keys_merge_into_each_alternative() -> None:
+    """A `types:` mapping at the top level applies to whichever alt wins."""
+    settings = {
+        "line_separator": r"\n",
+        "types": {"qty": "int"},
+        "alternatives": [_ALT_A, _ALT_B],
+    }
+    rows = lines_parser.parse(_TPL, "lines", settings, _CONTENT_A_ONLY)
+    assert rows == [{"sku": "SKU42", "qty": 3}, {"sku": "SKU7", "qty": 1}]
+
+
+def test_per_alternative_override_beats_shared_top_level() -> None:
+    """An alternative's own key wins over the shared top-level value."""
+    # Top-level `line` would match SKU rows; alternative B overrides it to
+    # match a completely different shape (Cxx rows), so on B-only content the
+    # B alternative wins with its own `line` pattern -- not the shared one.
+    settings = {
+        "line_separator": r"\n",
+        "line": r"^(?P<sku>SKU\d+)\s+(?P<qty>\d+)$",  # shared default
+        "alternatives": [
+            {"start": r"BEGIN A", "end": r"END A"},  # inherits shared `line`
+            {
+                "start": r"BEGIN B",
+                "end": r"END B",
+                "line": r"^(?P<code>C\d+)\s+(?P<count>\d+)$",  # override
+            },
+        ],
+    }
+    rows = lines_parser.parse(_TPL, "lines", settings, _CONTENT_B_ONLY)
+    assert rows == [{"code": "C99", "count": "5"}]
+
+
+def test_alternatives_and_rules_together_warns_and_prefers_alternatives(
+    caplog: "logging.LogCaptureFixture",
+) -> None:
+    """`alternatives:` wins over `rules:` at the same level; log a warning."""
+    settings = {
+        "line_separator": r"\n",
+        "rules": [
+            # If `rules` were honoured here it would concatenate and return
+            # BOTH the A rows AND the B rows.
+            _ALT_A,
+            _ALT_B,
+        ],
+        "alternatives": [_ALT_A, _ALT_B],
+    }
+    with caplog.at_level(logging.WARNING, logger=lines_parser.__name__):
+        rows = lines_parser.parse(_TPL, "lines", settings, _CONTENT_A_AND_B)
+    # First-non-empty-wins -> only A's row, not A+B concatenated.
+    assert rows == [{"sku": "SKU1", "qty": "1"}]
+    assert any(
+        "'alternatives' takes precedence" in rec.getMessage() for rec in caplog.records
+    )
+
+
+def test_single_mapping_and_rules_still_work_unchanged() -> None:
+    """Backward-compat smoke: neither `alternatives:` nor `rules:` -> old path."""
+    # Single-mapping path.
+    single = {**_ALT_A, "line_separator": r"\n"}
+    assert lines_parser.parse(_TPL, "lines", single, _CONTENT_A_ONLY) == [
+        {"sku": "SKU42", "qty": "3"},
+        {"sku": "SKU7", "qty": "1"},
+    ]
+    # Rules-concatenate path.
+    rules = {
+        "line_separator": r"\n",
+        "rules": [_ALT_A, _ALT_B],
+    }
+    assert lines_parser.parse(_TPL, "lines", rules, _CONTENT_A_AND_B) == [
+        {"sku": "SKU1", "qty": "1"},
+        {"code": "C2", "count": "2"},
+    ]


### PR DESCRIPTION
Closes discussion in #759 (design + implementation option laid out there).

## Summary

Adds `alternatives:` to the lines-parser field form so a template can express
"try layout A; if A yields nothing, fall back to layout B" without stuffing
two blocks into one YAML mapping (where the first is silently dropped by
key-collision — see #756).

`alternatives:` is parallel to the existing `rules:` key, not a replacement:

|              | `rules:`         | `alternatives:`               |
|--------------|------------------|-------------------------------|
| Semantic     | concatenate all  | first-non-empty wins          |
| Use case     | two structurally distinct regions of the same invoice | one of these layouts, not both |
| Nesting      | —                | can wrap a `rules:` per-alt   |

```yaml
fields:
  lines:
    parser: lines
    types: {qty: int}                # shared defaults
    alternatives:
      - start: BEGIN NEW
        end: END
        line: (?P<code>C\d+)\s+(?P<qty>\d+)
      - start: Order                 # legacy, only if the new layout misses
        end: Total
        line: (?P<sku>SKU\d+)\s+(?P<qty>\d+)
```

Keys set outside `alternatives:` merge into each entry as shared defaults;
per-alternative keys override. `alternatives + rules` at the same level:
`alternatives` wins, `rules` is ignored at that level (warning logged); a
single alternative can still use `rules:` internally.

## Implementation

- `src/invoice2data/extract/parsers/lines.py`: split `parse()` into an
  `alternatives`-aware dispatcher and a `_parse_single()` helper that
  holds the existing rules-or-single logic unchanged.
- No behavioural change on the single-mapping or `rules:`-only paths.

## Tests

Seven scenarios in `tests/test_lines_alternatives.py`:
- first alt matches → its rows returned, later alts not consulted
- first alt empty → second alt runs and returns its rows
- all empty → returns `[]`
- shared top-level `types:` applies to whichever alt wins
- per-alt `line:` overrides shared default
- `rules:` + `alternatives:` at same level → warns and prefers `alternatives`
- single-mapping and `rules:`-only paths still work unchanged (backward-compat smoke)

All 18 lines-parser tests pass locally (`pytest tests/test_lines_alternatives.py tests/test_cross_page_lines.py tests/test_lines_replace.py tests/test_tax_lines.py`).

## Docs

New "Layout alternatives (`alternatives:`)" subsection in
`docs/recommended-template-fields.md` with the example above and a
`rules:` vs `alternatives:` contrast.

## Test plan
- [x] Local: `uv run pytest tests/test_lines_alternatives.py` — 7/7 green
- [x] Local: existing lines suites still green — 11/11
- [x] `ruff check` clean; `ruff format --check` clean
- [ ] CI: full test matrix + mypy
- [ ] Reviewer sanity: shape of the YAML in the new docs section

## Follow-up

Unblocks reconsidering PR #746's top-level `lines:` deprecation — the field
form is now strictly more expressive for the motivating case, so the
deprecation is honest.