### PR TITLE
fix(template_builder): tighten suggested BIC/VAT/IBAN value patterns

### DIFF
--- a/src/invoice2data/extract/template_builder.py
+++ b/src/invoice2data/extract/template_builder.py
@@ -19,12 +19,22 @@ from .suggestions import suggest_fields
 
 
 #: Capture pattern per candidate kind, used to build a field's value group.
+#: These are TIGHT patterns applied at *extraction* time -- when the suggested
+#: template is later run against a fresh PDF the label alone isn't enough to
+#: anchor a value, so an overly loose pattern (``[A-Z0-9]+`` for BIC/VAT)
+#: would grab any adjacent alphanumeric blob. The shapes here mirror the
+#: strict validators in ``validators.py`` so a suggestion produces a regex
+#: that will only re-match a properly shaped identifier.
 _VALUE_PATTERNS = {
     "date": r"\d[\d/.\-]+\d",
     "amount": r"[\d.,]+",
-    "iban": r"[A-Z0-9 ]+",
-    "vat": r"[A-Z0-9]+",
-    "bic": r"[A-Z0-9]+",
+    # Contiguous or space-grouped IBAN body -- capture then strip in-app.
+    "iban": r"[A-Z]{2}\d{2}(?:[ \-]?[A-Z0-9]){11,30}",
+    # VAT: 2-letter country + 8-14 alphanumerics. Country slot MUST be alpha.
+    "vat": r"[A-Z]{2}[A-Z0-9]{8,14}",
+    # BIC / SWIFT (ISO 9362): 8 or 11 chars, first 6 letters, then 2 alnum,
+    # optionally 3 more (branch).
+    "bic": r"[A-Z]{6}[A-Z0-9]{2}(?:[A-Z0-9]{3})?",
 }
 
 

--- a/tests/test_template_builder.py
+++ b/tests/test_template_builder.py
@@ -37,6 +37,31 @@ def test_field_regex_anchors_on_label() -> None:
     assert match.group(1) == "121.00"
 
 
+def test_bic_value_pattern_only_captures_bic_shape() -> None:
+    """A suggested BIC regex must not slurp arbitrary alphanumeric blobs.
+
+    Regression: the value pattern used to be ``[A-Z0-9]+`` which, when the
+    suggestion was later applied to a fresh PDF, gobbled adjacent uppercase
+    tokens (order codes, postal codes, single letters). Now the ISO-9362
+    shape is enforced at extraction time.
+    """
+    text = "ACME Corp\nInvoice #ORDER12345\nBank: DEUTDEFFXXX\n"
+    template = suggested_template(text)
+    bic_pattern = template["fields"].get("bic")
+    assert bic_pattern, "expected a bic suggestion"
+    matches = re.findall(bic_pattern, text)
+    assert matches == ["DEUTDEFFXXX"], (
+        f"tight pattern should only capture the actual BIC; got {matches!r}"
+    )
+    # Explicitly: an 8-char order code alone should NOT match the bic pattern
+    # even without any surrounding label anchor.
+    from invoice2data.extract.template_builder import _VALUE_PATTERNS
+
+    assert re.fullmatch(_VALUE_PATTERNS["bic"], "ORDER123") is None
+    assert re.fullmatch(_VALUE_PATTERNS["bic"], "DEUTDEFF") is not None
+    assert re.fullmatch(_VALUE_PATTERNS["bic"], "DEUTDEFFXXX") is not None
+
+
 def test_to_yaml_roundtrips() -> None:
     template = {
         "issuer": "ACME",


### PR DESCRIPTION
## Summary

\`_VALUE_PATTERNS\` in \`src/invoice2data/extract/template_builder.py\` used loose regexes:

\`\`\`
'iban': r'[A-Z0-9 ]+',
'vat':  r'[A-Z0-9]+',
'bic':  r'[A-Z0-9]+',
\`\`\`

These patterns are embedded into every field regex the CLI builder / db_templates \"Suggest fields\" wizard produces. On the *sample* document a suggestion is built from, the candidate detector's own strict pattern anchors things correctly — but when the *same* suggested template is later applied to a fresh PDF, the loose pattern happily grabs any adjacent uppercase-alnum blob near the label. An order code like \`ORDER12345\` matches the \`bic\` slot; downstream (Odoo's \`base_business_document_import\`) then rejects the field and the import fails.

Tighten each pattern to mirror the strict validators in \`validators.py\`:

| kind | old         | new                                              |
|------|-------------|--------------------------------------------------|
| BIC  | \`[A-Z0-9]+\` | \`[A-Z]{6}[A-Z0-9]{2}(?:[A-Z0-9]{3})?\` — ISO 9362 |
| VAT  | \`[A-Z0-9]+\` | \`[A-Z]{2}[A-Z0-9]{8,14}\`                         |
| IBAN | \`[A-Z0-9 ]+\` | \`[A-Z]{2}\\d{2}(?:[ \\-]?[A-Z0-9]){11,30}\`      |

## Test

\`tests/test_template_builder.py::test_bic_value_pattern_only_captures_bic_shape\` — a doc containing both an order code and a valid BIC. Old pattern captured both; the tight one captures only the BIC.

All six template-builder tests green locally.

## Test plan

- [x] \`pytest tests/test_template_builder.py\` — 6/6
- [x] \`ruff check\` / \`ruff format --check\` clean
- [ ] CI: full matrix

Reported downstream while iterating on the account_invoice_import_invoice2data_db_templates \"Suggest Fields\" wizard (OCA/edi#1365) — Suggest was producing a BIC regex that captured an unrelated order code, so re-applying the template on a fresh PDF grabbed the wrong value.