### PR TITLE
docs(readme): update roadmap — all listed items are shipped; fix stale pypdf_table_extraction link

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,11 +101,36 @@ If you are interested in improving this project, have a look at our
 
 ## Roadmap and open tasks
 
-- integrate with online OCR?
-- try to 'guess' parameters for new invoice formats.
-- apply machine learning to guess new parameters / template creation
-- Data cleanup per field
-- advanced table parsing with [pypdf_table_extraction](https://github.com/py-pdf/pypdf_table_extraction)
+Everything that used to live here has shipped:
+
+- online OCR — Google [Cloud Vision][gvision], plus local DL backends [docTR][doctr] and [PaddleOCR][paddleocr]
+- guess parameters for new invoice formats — `invoice2data --new-template SAMPLE` (deterministic, no AI needed)
+- ML-assisted template creation — `invoice2data --new-template SAMPLE --ai` (AI-1) and runtime `--ai-fallback` (AI-2); see the [AI features][ai] page
+- per-field data cleanup — the `replace:` key on each field
+- advanced table parsing — opt-in [Camelot][camelot] plugin (`pip install invoice2data[camelot]`), plus an [Excalibur → template converter][usage-excalibur]
+
+Currently open on the tracker:
+
+- **Non-invoice document schemas** (waybills, delivery notes, purchase orders): the
+  per-template `required_fields:` override lets a template opt out of the
+  invoice-shaped default today, but canonical schemas for other document
+  types are still deferred.
+- **Visual template builder in Odoo** — community-driven via [OCA/edi][odoo-oca-edi]
+  (`account_invoice_import_invoice2data_db_templates`, in review). Wraps the
+  authoring APIs listed above in a click-to-suggest UI on top of the disk
+  templates.
+- Tighter identifier validators via [python-stdnum][python-stdnum] — deferred
+  pending Odoo core's stdnum version alignment.
+
+Issues and pull requests welcome on any of these.
+
+[gvision]: https://cloud.google.com/vision
+[doctr]: https://github.com/mindee/doctr
+[paddleocr]: https://github.com/PaddlePaddle/PaddleOCR
+[camelot]: https://github.com/camelot-dev/camelot
+[usage-excalibur]: https://invoice2data.readthedocs.io/en/latest/usage.html
+[odoo-oca-edi]: https://github.com/OCA/edi
+[python-stdnum]: https://arthurdejong.org/python-stdnum/
 
 ## Maintainers
 


### PR DESCRIPTION
## Summary

The README's "Roadmap and open tasks" section pointed to `pypdf_table_extraction`, which has been reverted upstream to **Camelot**. Beyond the link, an audit of the five bullets shows every one of them shipped since the section was last touched:

| Roadmap bullet | Status |
|---|---|
| integrate with online OCR | shipped — `gvision` (Google Cloud Vision), `doctr`, `paddleocr` |
| guess parameters for new formats | shipped — `invoice2data --new-template SAMPLE` (deterministic AUTH-3 CLI) |
| ML to guess parameters | shipped — `--new-template --ai` (AI-1) + runtime `--ai-fallback` (AI-2) |
| data cleanup per field | shipped — per-field `replace:` (issue #497) |
| advanced table parsing | shipped — opt-in Camelot plugin (`pip install invoice2data[camelot]`) |

## What this PR does

- Rewrites the section as DONE items with links to the docs pages that already document each.
- Fixes the broken `pypdf_table_extraction` link → `Camelot`.
- Replaces the shipped bullets with what is genuinely still open:
  - non-invoice document schemas (waybills, delivery notes, POs) — the per-template `required_fields:` override lets a template opt out today, but canonical schemas for other document types are still deferred;
  - visual template builder UI in Odoo — community-driven via OCA/edi (in review);
  - tighter identifier validators via `python-stdnum` — deferred pending Odoo-core version alignment.

## Test plan
- [x] `grep -rn 'pypdf_table_extraction'` — no leftover references anywhere in `*.md/*.rst/*.py`.
- [x] All new link definitions have targets.

Reported downstream while iterating on the OCA/edi `account_invoice_import_invoice2data_db_templates` module (PR #1365).