### PR TITLE
fix(candidates+labels): tighten date pattern so a ZIP + partial date is not one 'date'

### DIFF
--- a/src/invoice2data/extract/candidates.py
+++ b/src/invoice2data/extract/candidates.py
@@ -39,10 +39,23 @@ class Candidate:
     parsed: Any
 
 
+# Month-name alternation, case-insensitive. English full names + English/Dutch/
+# German/French/Spanish/Italian common short forms. Deliberately narrow: a
+# generic ``[A-Za-z]{3,9}`` alt would match labels like "Date" or "Due" as
+# months and swallow adjacent digits, producing spurious "date" candidates.
+_MONTH = (
+    r"(?i:"
+    r"jan(?:uary)?|feb(?:ruary)?|mar(?:ch|z)?|mrt|apr(?:il)?|may|"
+    r"mai|mei|jun[ei]?|jul[yi]?|aug(?:ust)?|sep(?:t(?:ember)?)?|"
+    r"oct(?:ober)?|okt|nov(?:ember)?|dec(?:ember)?|dez|dic"
+    r")"
+)
 _DATE_RE = re.compile(
-    r"\b\d{1,4}[/.\-]\d{1,2}[/.\-]\d{1,4}\b"  # 2024-05-12, 12/05/2024
-    r"|\b\d{1,2}\s+[A-Za-z]{3,9}\.?\s+\d{2,4}\b"  # 12 May 2024
-    r"|\b[A-Za-z]{3,9}\.?\s+\d{1,2},?\s+\d{2,4}\b"  # May 12, 2024
+    r"\b\d{1,4}[/.\-]\d{1,2}[/.\-]\d{1,4}\b"  # 2024-05-12, 12/05/2024, 06/09/26
+    # dd-mon-yyyy / dd mon yyyy / dd.mon.yyyy — separator can be dash, dot,
+    # slash or whitespace so "6-sept-2026", "6.sep.2026", "6 Sept 2026" all hit.
+    rf"|\b\d{{1,2}}[\s.\-/]+{_MONTH}\.?[\s,.\-/]+\d{{2,4}}\b"
+    rf"|\b{_MONTH}\.?[\s.\-/]+\d{{1,2}},?[\s.\-/]+\d{{2,4}}\b"  # May 12, 2024
 )
 _AMOUNT_RE = re.compile(
     r"(?<![\d.,])\d{1,3}(?:[.,\s]\d{3})+[.,]\d{2}(?!\d)"  # grouped: 1.234,56

--- a/src/invoice2data/extract/labels.py
+++ b/src/invoice2data/extract/labels.py
@@ -49,7 +49,15 @@ _COC = (
 _DOCNO = r"(?=[A-Za-z0-9.\-/]*\d)[A-Za-z0-9][A-Za-z0-9.\-/]{2,20}"
 _IBAN = r"[A-Z]{2}\d{2}[A-Z0-9 ]{10,30}"
 _BIC = r"[A-Z0-9]{8,11}"
-_DATE = r"\d[\d /.\-]{6,12}\d"
+# Date-shape alternatives. The prior ``\d[\d /.\-]{6,12}\d`` was too loose:
+# it happily spanned across a ZIP + trailing text (e.g. "18503 04/04" matched
+# as one "date"), so a nearby ``Date`` label captured a run starting inside
+# an address block. Enforce a real separator between parts.
+_DATE = (
+    r"\d{1,4}[-/.]\d{1,2}[-/.]\d{1,4}"  # 2024-05-12, 12/05/2024, 06/09/26
+    r"|\d{1,2}[-/. ]+[A-Za-z]{3,9}\.?,?[-/. ]+\d{2,4}"  # 6 sept 2026, 6-Sept-2026
+    r"|[A-Za-z]{3,9}\.?[-/. ]+\d{1,2},?[-/. ]+\d{2,4}"  # Sept 6, 2026
+)
 _AMOUNT = r"[\d., ]{2,15}\d"
 
 #: Ordered so more specific fields claim their span first (e.g. ``Due Date``

--- a/tests/test_candidates.py
+++ b/tests/test_candidates.py
@@ -50,3 +50,20 @@ def test_find_candidates_sorted_by_position() -> None:
     cands = find_candidates("Total 10.00 on 2024-01-02 ref DEUTDEFF")
     assert cands == sorted(cands, key=lambda c: c.start)
     assert all(isinstance(c, Candidate) for c in cands)
+
+
+def test_find_dates_recognises_month_name_with_dash() -> None:
+    """Real-world dash-separated month-name dates: `6-sept-2026`, `6-Sep-26`."""
+    for value in ("6-sept-2026", "6-Sep-26", "6.sep.2026"):
+        cands = find_candidates("Invoice date %s here" % value)
+        dates = [c for c in cands if c.kind == "date"]
+        assert dates, "no date candidate for %r" % value
+        assert dates[0].value == value, (value, dates[0].value)
+
+
+def test_find_dates_recognises_short_year_slash() -> None:
+    """`06/09/26` (dd/mm/yy) must be picked up as a date candidate."""
+    cands = find_candidates("Invoice date 06/09/26")
+    dates = [c for c in cands if c.kind == "date"]
+    assert dates
+    assert dates[0].value == "06/09/26"

--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -73,3 +73,25 @@ def test_coc_cleanup_keeps_only_digits() -> None:
     assert preview_field(
         template["fields"]["partner_coc"], "KvK 12345678 Amsterdam"
     ) == ("12345678")
+
+
+def test_date_label_does_not_grab_zip_and_partial_date() -> None:
+    r"""Date label must not span a ZIP + partial date.
+
+    Regression: `\d[\d /.\-]{6,12}\d` was loose enough to match a run
+    like '18503 04/04' as one 'date', so a nearby ``Date`` label captured
+    a span starting inside an address block. Require a real separator
+    between date parts.
+    """
+    text = "Vendor Ltd\nFremont CA 94538\n18503 United States\nDate: 03/20/2023\n"
+    found = find_labeled_fields(text)
+    # The label match must capture ONLY the actual date, not the ZIP.
+    assert found["date"].value == "03/20/2023", found["date"].value
+
+
+def test_date_label_accepts_month_name_with_dashes() -> None:
+    """Real-world formats like `6-sept-2026` and `6.9.2026` must match."""
+    for value in ("6-sept-2026", "6 Sept 2026", "6.sep.2026", "06/09/26"):
+        found = find_labeled_fields("Invoice Date: %s\n" % value)
+        assert found.get("date") is not None, value
+        assert found["date"].value == value, (value, found["date"].value)


### PR DESCRIPTION
## Summary

Reported downstream (OCA/edi template builder): Guided Suggest for the DATE field captured a ZIP + partial date as a single "date" value, e.g. `18503 04/04` on an invoice where the `Date` label sat one line below the address block.

Two date regexes were too loose:

### 1. `labels._DATE = r'\d[\d /.\-]{6,12}\d'`

Any 8-14 char run of digits + space/dot/slash/dash bounded by digits. That's happy to span from inside a ZIP into the first half of an actual date, so a nearby `Date` label anchor picks up the wrong span. Replace with alternatives that each require a real numeric or month-name separator between parts:

```
\d{1,4}[-/.]\d{1,2}[-/.]\d{1,4}                    # 2024-05-12, 12/05/2024, 06/09/26
| \d{1,2}[-/. ]+[A-Za-z]{3,9}\.?,?[-/. ]+\d{2,4}   # 6 sept 2026, 6-Sept-2026
| [A-Za-z]{3,9}\.?[-/. ]+\d{1,2},?[-/. ]+\d{2,4}   # Sept 6, 2026
```

### 2. `candidates._DATE_RE` third alt: `\b[A-Za-z]{3,9}\.?\s+\d{1,2},?\s+\d{2,4}\b`

The letter class accepts *any* 3-9 letter word, so on a line like `Date 12.05.2024`, "Date 12.05" matched as a "date" and swallowed the digits — preventing the *real* `12.05.2024` from being detected. Replace `[A-Za-z]{3,9}` with an actual month-name alternation (case-insensitive, English full names + English/Dutch/German/French/Spanish/Italian common short forms):

```
(?i: jan(uary)? | feb(ruary)? | mar(ch|z)? | mrt | apr(il)? | may
   | mai | mei | jun[ei]? | jul[yi]? | aug(ust)? | sep(t(ember)?)?
   | oct(ober)? | okt | nov(ember)? | dec(ember)? | dez | dic )
```

The same alternation is used in the `dd mon yyyy` (dash/dot separator ok) and `mon dd, yyyy` alts, so real-world formats like `6-sept-2026`, `6.sep.2026`, `06/09/26`, `May 12, 2024` all detect cleanly, while a label like `Date` cannot masquerade as a month.

## Tests

- `test_date_label_does_not_grab_zip_and_partial_date` — the reproduction from the downstream report.
- `test_date_label_accepts_month_name_with_dashes` — four format variants each go through `find_labeled_fields`.
- `test_find_dates_recognises_month_name_with_dash` and `test_find_dates_recognises_short_year_slash` — candidate-side coverage.

All 22 candidate/label/template_builder tests pass locally.

## Test plan
- [x] `pytest tests/test_candidates.py tests/test_labels.py tests/test_template_builder.py` — 22/22
- [x] `ruff check` / `ruff format --check` clean
- [ ] CI: full matrix